### PR TITLE
Add page for Full Site Editing Outreach Program

### DIFF
--- a/archive/full-site-editing-outreach-experiment.md
+++ b/archive/full-site-editing-outreach-experiment.md
@@ -1,0 +1,55 @@
+# Full Site Editing Outreach Program
+
+---
+
+> *This page serves as a historical record for the FSE Outreach Program in case future outreach programs are created. To see the latest information, please view this post on [Evolving the FSE Outreach Program](https://make.wordpress.org/core/2023/09/07/evolving-the-fse-outreach-program/). For context on this program's origins, please review [this post](https://make.wordpress.org/core/2020/05/01/an-experimental-outreach-project-for-full-site-editing/) shared on May 1st, 2020 kicking off this initiative.*
+
+## Program Goal
+
+The primary goal is to help improve the Full Site Editing experience by gathering feedback from WordPress site builders. Alongside this main goal, the program also seeks to grow awareness and ability with full site editing features. This program does not replace [sharing feedback on GitHub](https://github.com/wordpress/gutenberg/) so, whether you're a part of this program or not, please keep sharing there.
+
+## How to join
+
+Simply create a [WordPress slack account](https://make.wordpress.org/chat/) and join the channel #fse-outreach-experiment. From there, you can help respond to calls for testing and stay up to date on what's happening with the program.
+
+## Approach
+
+We'll start with more limited common user experiences and, over time, will move to more complex testing (adding in different themes, plugins, etc). For example, this means that we won't be testing across a wide range of themes, but will start with a fairly simple setup of Gutenberg and a FSE ready block theme. While this might mean the program starts off more slowly, over time, the hope is that we get into a fast pace with multiple items to test each month and feedback integrating into the Gutenberg team's workflow.
+
+## Communication
+
+All calls for testing and summaries will be shared on [Make Test](https://make.wordpress.org/test/) with a cross post to [Make Core](https://make.wordpress.org/core/). Here are the tags you can use to follow along specifically:
+
+- Calls for testing: [#fse-testing-call](https://make.wordpress.org/test/tag/fse-testing-call/)
+- Summaries of feedback from calls for testing: [#fse-testing-summary](https://make.wordpress.org/test/tag/fse-testing-summary/)
+- Summaries of hallway hangouts: [#fse-hallway-hangouts](https://make.wordpress.org/test/tag/fse-hallway-hangout/)
+- All posts: [#fse-outreach-program](https://make.wordpress.org/test/tag/fse-outreach-program/)
+
+As much as possible, please communicate in #fse-outreach-experiment openly about the program itself. While you can always DM @annezazu separately, it's preferred to communicate in the open. When you ask your question in the open channel, it helps everyone learn, even the people who might have been too shy to ask the same thing.
+
+If you have questions about the FSE project separate from this outreach program, it's best to ask in #core-editor.
+
+To help stay up to date on the FSE work itself, please review this post on [ways to keep up with FSE](https://make.wordpress.org/core/2020/05/20/ways-to-keep-up-with-full-site-editing-fse/).
+
+## Amplification
+
+To get the word out to more people who can help test, the following pathways are used to amplify the calls for testing:
+
+- Messages in the #fse-outreach-experiment slack channel.
+- Make Test posts with cross posts to Make Core.
+- Inclusion in "This Month in WordPress" posts.
+- Inclusion in various meeting including Core Dev, Core Editor, and Marketing.
+- Initial email distribution list from [this original call for volunteers](https://make.wordpress.org/core/2020/05/01/an-experimental-outreach-project-for-full-site-editing/) to help with testing. This will *only* be used in the first few rounds of testing.
+
+## Format
+
+A prompt will be shared on [Make Test](https://make.wordpress.org/test/) with details about testing environment, a testing script to follow, and where to give feedback by when. For now, feedback will be processed and reported appropriately. From there, a [follow up post](https://make.wordpress.org/test/tag/fse-testing-summary/) summarizing the findings will be posted.
+
+## Tools
+
+While you are free to use your own testing environment and follow [these instructions](https://make.wordpress.org/test/handbook/get-setup-for-testing/), we wanted to share basic tools you'll need to get started:
+
+- [Gutenberg.run](http://gutenberg.run/): The tool to spin up and test Gutenberg PRs.
+- [Theme Experiments](https://github.com/wordpress/theme-experiments/): A repository of block themes to use for testing or one of the current block themes in the Themes Repo ([Q](https://wordpress.org/themes/q/), [Bosco](https://wordpress.org/themes/block-based-bosco/)). We ask that you use one of these themes for consistency.
+- [GIPHY Capture](https://giphy.com/) or [LICEcap](https://www.cockos.com/licecap/): Tools to capture GIFs to better highlight any bugs you might run into.
+

--- a/archive/full-site-editing-outreach-experiment/index.md
+++ b/archive/full-site-editing-outreach-experiment/index.md
@@ -1,8 +1,8 @@
 # Full Site Editing Outreach Program
 
----
-
-> *This page serves as a historical record for the FSE Outreach Program in case future outreach programs are created. To see the latest information, please view this post on [Evolving the FSE Outreach Program](https://make.wordpress.org/core/2023/09/07/evolving-the-fse-outreach-program/). For context on this program's origins, please review [this post](https://make.wordpress.org/core/2020/05/01/an-experimental-outreach-project-for-full-site-editing/) shared on May 1st, 2020 kicking off this initiative.*
+<div class="callout callout-info">
+> *This page serves as a historical record for the FSE Outreach Program in case future outreach programs are created. To see the latest information, please view this post on <a href="https://make.wordpress.org/core/2023/09/07/evolving-the-fse-outreach-program/">Evolving the FSE Outreach Program</a>. For context on this program's origins, please review <a href="https://make.wordpress.org/core/2020/05/01/an-experimental-outreach-project-for-full-site-editing/">this post</a> shared on May 1st, 2020 kicking off this initiative.
+</div>
 
 ## Program Goal
 
@@ -52,4 +52,3 @@ While you are free to use your own testing environment and follow [these instruc
 - [Gutenberg.run](http://gutenberg.run/): The tool to spin up and test Gutenberg PRs.
 - [Theme Experiments](https://github.com/wordpress/theme-experiments/): A repository of block themes to use for testing or one of the current block themes in the Themes Repo ([Q](https://wordpress.org/themes/q/), [Bosco](https://wordpress.org/themes/block-based-bosco/)). We ask that you use one of these themes for consistency.
 - [GIPHY Capture](https://giphy.com/) or [LICEcap](https://www.cockos.com/licecap/): Tools to capture GIFs to better highlight any bugs you might run into.
-


### PR DESCRIPTION
Adds the historical FSE Outreach Program page to the archived section of the handbook.

Closes #46 