### PR TITLE
docs: fix spelling across handbook

### DIFF
--- a/call-for-testing.md
+++ b/call-for-testing.md
@@ -101,6 +101,6 @@ This section only applies if you are doing facilitated calls for testing. Summar
 - A high level summary with important takeaways.
 - List of any bugs.
 - List of feature requests.
-- Quotes/videos/images/etc to contextualize the more quantitive feedback and examine the broader experience being tested.
+- Quotes/videos/images/etc to contextualize the more quantitative feedback and examine the broader experience being tested.
 
 In terms of format, this will vary based on what’s being tested. For example, you might want to group related feedback for a feature under a heading (“General Usability feedback”) or you might want to keep things more general (“General Usability feedback”). Here’s an [example of a more general summary](https://make.wordpress.org/test/2021/12/16/fse-program-site-editing-safari-summary/) and an [example of one with more specific headings](https://make.wordpress.org/test/2021/10/05/fse-program-block-theme-switching-summary/) based on common groupings of feedback.

--- a/get-setup-for-testing/index.md
+++ b/get-setup-for-testing/index.md
@@ -35,7 +35,7 @@ Use this option to do general testing with the latest beta or release candidate 
 
 *All of these commands are intended to be run from Terminal, in your Gutenberg directory.*
 
-- Running `npm install` occasionally is a useful habit, as well as any time you know that `packages.json` has been changed.  
+- Running `npm install` occasionally is a useful habit, as well as any time you know that `package.json` has been changed.  
 - If you restart your computer, or upgrade Docker, start the Gutenberg containers again by running: `docker-compose up -d`
 - It’s a good practice to stop (with `Ctrl+C`) `npm run dev` and restart when you switch to a different branch.  
 - If everything is broken, and you have no idea what’s happened, run `bin/setup-local-env.sh` again to reset everything to a fresh install.

--- a/test-reports/testing-instructions.md
+++ b/test-reports/testing-instructions.md
@@ -4,7 +4,7 @@ Testing Instructions provide a list of steps for testers to follow in reproducin
 Adding these instructions within the ticket provides needed testing information without testers having to duplicate the same information over and over in test reports.
 
 ## Test Report Icons
-Always remember to use thse icons to facilitate the visual inspection.
+Always remember to use these icons to facilitate the visual inspection.
 
 - 🐞 => Indicates where issue ("bug") occurs.
 - ✅ => Behavior is ''expected''.


### PR DESCRIPTION
I found a few spelling mistakes and corrected them across the docs. 
Please review the changes, and if the fixes look correct, kindly merge this PR. Thanks!