### PR TITLE
Updating the Test Handbook Homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,16 +7,19 @@ While the Test Team originally stemmed from the [Core Team](https://make.wordpre
 
 Test Team contributions touch on all aspects of manual and automated testing within the project, including:
 
-- [WordPress release beta testing](https://make.wordpress.org/core/handbook/testing/beta-testing/) and [editor pre-release testing](https://make.wordpress.org/test/handbook/gutenberg-testing/regression-testing/)
-- [full site editing (FSE) outreach](https://make.wordpress.org/test/handbook/full-site-editing-outreach-experiment/)
-- [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/#2-issue-reproduction) and [patch testing](https://make.wordpress.org/test/handbook/test-reports/#3-patch-testing)
-- feature and enhancement testing
-- PHP and JavaScript unit testing
-- end-to-end (E2E) testing
-- [issue triage and bug scrubs](https://make.wordpress.org/core/handbook/testing/bug-gardening/)
-- education, outreach, and documentation
+- [Issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/) 
+- [Patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/)
+- Feature and enhancement testing
+- End-to-end (E2E) testing
+- Patch testing scrubbing
+- Education, outreach, and documentation
 
 With such a wide range of opportunities available, contributors are sure to find an area of interest to help make WordPress better.
+
+## New Initiatives
+The Test Team is continually evolving to meet the needs of the WordPress project. Currently all the discussions and planning for new initiatives are going to be happening in the [Test Handbook Github page](https://github.com/WordPress/test-handbook).
+
+If you want to propose a new initiative or help with an existing one, please open an issue in the repository to start the conversation and eventually we will bring it to the Test Chat if further discussion is needed.
 
 ## Contributors Welcome
 Contributors to testing have a wide variety of experience and technical knowledge, from beginners with little WordPress experience to seasoned developers who have contributed for years.
@@ -31,10 +34,9 @@ In addition to posts and discussions in the [Test Team blog](https://make.wordpr
 ## Get Started
 Ready to get started? Here are some links to get you on your way:
 
-- [Join the #fse-outreach-program](https://make.wordpress.org/test/handbook/full-site-editing-outreach-experiment/) -- the fastest way to get testing
 - [Guidelines for writing great Test Reports](https://make.wordpress.org/test/handbook/test-reports/)
-- [Tickets needing issue reproduction (created in the last week)](https://core.trac.wordpress.org/query?status=new&focuses=!docs&time=1weekago..&component=!Build%2FTest+Tools&keywords=~-reporter-feedback+-close+-dev-feedback+-2nd-opinion+-needs-refresh+-needs-design+-needs-design-feedback&milestone=Awaiting+Review&owner=&type=defect+(bug)&col=id&col=summary&col=focuses&col=keywords&col=changetime&order=changetime)
-- [Tickets needing patch testing (modified in the last week)](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&changetime=1weekago..&keywords=~needs-testing+has-patch+-dev-feedback+-2nd-opinion+-close+-needs-refresh+-needs-design+-needs-design-feedback+-changes-requested&milestone=!Awaiting+Review&col=id&col=summary&col=status&col=milestone&col=changetime&col=keywords&col=type&col=priority&col=component&order=changetime)
-- [Tickets needing unit tests (modified in the last month)](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&changetime=1monthago..&keywords=~needs-unit-tests+has-patch+-dev-feedback+-2nd-opinion+-close+-needs-refresh+-needs-design+-needs-design-feedback&col=id&col=summary&col=status&col=keywords&col=type&col=priority&col=milestone&col=component&col=changetime&order=changetime)
+- [Tickets needing issue reproduction](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&keywords=~needs-testing+-has-patch&milestone=!&milestone=!Awaiting+Review&col=id&col=summary&col=status&col=milestone&col=changetime&col=keywords&col=type&col=priority&col=component&order=changetime)
+- [Tickets needing patch testing](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&keywords=~needs-testing+has-patch&milestone=!Awaiting+Review&milestone=!&col=id&col=summary&col=status&col=milestone&col=changetime&col=keywords&col=type&col=priority&col=component&order=changetime)
 - [Editor issues needing testing](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Needs+Testing%22)
-- [Editor issues with automated testing requirements](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Automated+Testing%22) (e.g. unit or E2E tests)
+- [Editor pull requests needing testing](https://github.com/WordPress/gutenberg/pulls?q=is%3Aopen+is%3Apr+label%3A%22Needs+Testing%22)
+- [The Test Team Handbook Repository](https://github.com/WordPress/test-handbook/)


### PR DESCRIPTION
Fixes #88

This update aims to bring the new course of action for the Test Team focus supports

1. We are removing support for Unit Testing
2. We are removing temporarily support for Usability Testing (until a new proposal comes in the future)
3. We are removing support for Triaging and bug scrubbing tasks
4. We adding support for Patch Testing scrubs
5. We are adding full support for Issue repro and Patch Testing in Core Editor

Feel free to use this PR to discuss anything regarding the changes or the future focuses we have already proposed.

By the next week, and after 2 reviews, changes will be merged unless there is any opposition
