### PR TITLE
Update Test Contributor Badge requirements

### DIFF
--- a/test-team-profile-badges.md
+++ b/test-team-profile-badges.md
@@ -9,8 +9,12 @@ To earn a Test Contributor Badge, you must have completed at least **any the fol
 - Submitted five test reports for tickets, comprising an [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
 - Contributed with five new pages, reviews or both to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
-- Written five Test Chat Summaries or Led five Test Chat sessions
-- Has led five or more Patch Testing Sessions
+- Led a Test Chat session with the corresponding Test Chat Summary written afterwards.
+- Managed at least two Patch Testing Sessions.
+
+A combination of contributions that meet the above criteria is also acceptable. For example, submitting three test reports and contributing two pages to the Test Handbook, or doing a Patch Testing session and submitting three test reports are both valid paths to earning the badge. Just ensure that your contributions align with the criteria outlined above and send links to demonstrate your contributions when requesting the badge.
+
+Fixing typos or making minor edits to existing Test Handbook pages or Testing minor patches like Coding Standard updates does not qualify towards earning the Test Contributor Badge. Please focus on substantial contributions that have a meaningful impact on the Test Team and its processes, earning the badge should be a symbol of your significant involvement and dedication not a bureaucratic exercise.
   
 ## Test Team Badge 
  
@@ -25,4 +29,4 @@ If you meet the criteria above, please request a badge using the buttons below. 
 
 [![Request Test Contributor Badge](https://raw.githubusercontent.com/WordPress/test-handbook/refs/heads/trunk/assets/test-contributor-badge.svg)](https://profiles.wordpress.org/associations/test-contributor/) [![Request Test Team Badge](https://raw.githubusercontent.com/WordPress/test-handbook/refs/heads/trunk/assets/test-team-badge.svg)](https://profiles.wordpress.org/associations/test-team/)
 
-Upon request, a Test Team Rep will confirm your contribution(s) and assign you a badge. There will be a weekly review of contributions and badges will be awarded at that time. The Test Team will post updates on new profile badges awarded on the [Test Team blog](https://make.wordpress.org/test/). 
+Upon request, a Test Team Rep will confirm your contribution(s) and assign you a badge. There will be a weekly review of contributions and badges will be awarded at that time. The Test Team will post updates on new profile badges awarded on the [Test Team blog](https://make.wordpress.org/test/).

--- a/test-team-profile-badges.md
+++ b/test-team-profile-badges.md
@@ -4,11 +4,13 @@ This page offers comprehensive information about Test Team [Profile Badges](http
 
 ## Test Contributor Badge
 
-To earn a Test Contributor Badge, you must have completed at least **five of the following**:
+To earn a Test Contributor Badge, you must have completed at least **any the following**:
 
-- Submitted test reports for tickets, comprising an [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
-- Contributed with a new page or a review to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
+- Submitted five test reports for tickets, comprising an [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
+- Contributed with five new pages, reviews or both to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
+- Written five Test Chat Summaries or Led five Test Chat sessions
+- Has led five or more Patch Testing Sessions
   
 ## Test Team Badge 
  


### PR DESCRIPTION
Clarified requirements for earning a Test Contributor Badge by changing 'five of the following' to 'any the following' and specifying the number of submissions required.

Added the Test Chat Sessions, Patch testing sessions and Test chat summaries