### PR TITLE
Create Markdown text version of each report type

### DIFF
--- a/release-squad.md
+++ b/release-squad.md
@@ -74,7 +74,7 @@ Whenever possible, try to include a screenshot, animated GIF, video, or code sam
 - [Licecap](https://www.cockos.com/licecap/) - animated GIFs; great for micro demonstrations without sound
 - [HandBrake](https://handbrake.fr) - video resizing/compression/transcoding
 - [TinyPNG](https://tinypng.com) - image web optimization (WebP, PNG, JPEG)
-- [WordPress Playground]([https://wordpress.org/playground/](https://playground.wordpress.net/)) - one-click environments, which can be [pre-configured for tests or demos](https://wordpress.github.io/wordpress-playground/blueprints/)
+- [WordPress Playground](https://playground.wordpress.net/) - one-click environments, which can be [pre-configured for tests or demos](https://wordpress.github.io/wordpress-playground/blueprints/)
 - [WP Playground CLI](https://wordpress.github.io/wordpress-playground/developers/local-development/wp-playground-cli/)
  
 Here's an example workflow (on Mac) you might use to show how a feature works:

--- a/test-reports/combined-report.md
+++ b/test-reports/combined-report.md
@@ -6,6 +6,8 @@ Alternatively, testers can post testing instructions first (if not supplied), fo
 ## Bug/Defect Combined Report Template
 An example combined report might look like this (some sections removed for brevity):
 
+### For Trac (WikiFormatting)
+
 ```
 == Test Report
 
@@ -42,8 +44,48 @@ When testing the bugfix patch:
 - ✅ Issue resolved with patch.
 ```
 
+### For GitHub (Markdown)
+
+```markdown
+## Test Report
+
+Patch tested: REPLACE_WITH_PATCH_URL
+
+### Steps to Reproduce or Test
+1. First step.
+2. Second step.
+3. 🐞 Bug occurs.
+
+### Expected Results
+When testing a patch to validate it works as expected:
+- ✅ What should happen when running the test
+
+When reproducing a bug:
+- ❌ Error condition occurs.
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Actual Results
+When reproducing a bug/defect:
+- ❌ Error condition occurs.
+
+When testing the bugfix patch:
+- ✅ Issue resolved with patch.
+```
+
 ## Feature or Enhancement Combined Report Template
 An example combined report might look like this (some sections removed for brevity):
+
+### For Trac (WikiFormatting)
 
 ```
 == Test Report
@@ -74,6 +116,41 @@ Lists each expected result or behavior, i.e. what should happen when running the
   - Plugin 2 X.Y.Z
 
 === Actual Results
+- ✅ Expected result #1 works as expected with patch.
+- ✅ Expected result #2 works as expected with patch.
+```
+
+### For GitHub (Markdown)
+
+```markdown
+## Test Report
+
+Patch tested: REPLACE_WITH_PATCH_URL
+
+### Steps to Test
+1. First step.
+2. Second step.
+3. Third step.
+...
+N. Last step.
+
+### Expected Results
+Lists each expected result or behavior, i.e. what should happen when running the test(s):
+- ✅ Expected result #1
+- ✅ Expected result #2
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Actual Results
 - ✅ Expected result #1 works as expected with patch.
 - ✅ Expected result #2 works as expected with patch.
 ```

--- a/test-reports/combined-report.md
+++ b/test-reports/combined-report.md
@@ -6,7 +6,8 @@ Alternatively, testers can post testing instructions first (if not supplied), fo
 ## Bug/Defect Combined Report Template
 An example combined report might look like this (some sections removed for brevity):
 
-<pre><code>== Test Report
+```
+== Test Report
 
 Patch tested: REPLACE_WITH_PATCH_URL
 
@@ -38,12 +39,14 @@ When reproducing a bug/defect:
 - ❌ Error condition occurs.
 
 When testing the bugfix patch:
-- ✅ Issue resolved with patch.</code></pre>
+- ✅ Issue resolved with patch.
+```
 
 ## Feature or Enhancement Combined Report Template
 An example combined report might look like this (some sections removed for brevity):
 
-<pre><code>== Test Report
+```
+== Test Report
 
 Patch tested: REPLACE_WITH_PATCH_URL
 
@@ -72,4 +75,5 @@ Lists each expected result or behavior, i.e. what should happen when running the
 
 === Actual Results
 - ✅ Expected result #1 works as expected with patch.
-- ✅ Expected result #2 works as expected with patch.</code></pre>
+- ✅ Expected result #2 works as expected with patch.
+```

--- a/test-reports/issue-reproduction.md
+++ b/test-reports/issue-reproduction.md
@@ -14,6 +14,8 @@ Here is an example Reproduction Report starter template, which can be copied and
 
 Note that if Testing Instructions have already been provided, there shouldn’t be a need to list or duplicate those steps here, making this report short and succinct.
 
+### For Trac (WikiFormatting)
+
 ```
 == Reproduction Report
 This report validates that the issue can be reproduced.
@@ -39,4 +41,31 @@ This report validates that the issue can be reproduced.
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
 Add as Attachment
+```
+
+### For GitHub (Markdown)
+
+```markdown
+## Reproduction Report
+This report validates that the issue can be reproduced.
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Actual Results
+- ✅ Error condition occurs (reproduced).
+
+### Additional Notes
+- Any additional details worth mention.
+
+### Supplemental Artifacts
+![Image description](REPLACE_WITH_IMAGE_URL)
 ```

--- a/test-reports/issue-reproduction.md
+++ b/test-reports/issue-reproduction.md
@@ -14,7 +14,8 @@ Here is an example Reproduction Report starter template, which can be copied and
 
 Note that if Testing Instructions have already been provided, there shouldn’t be a need to list or duplicate those steps here, making this report short and succinct.
 
-<pre><code>== Reproduction Report
+```
+== Reproduction Report
 This report validates that the issue can be reproduced.
 
 === Environment
@@ -37,4 +38,5 @@ This report validates that the issue can be reproduced.
 === Supplemental Artifacts
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
-Add as Attachment</code></pre>
+Add as Attachment
+```

--- a/test-reports/patch-testing.md
+++ b/test-reports/patch-testing.md
@@ -12,7 +12,8 @@ Example patch testing reports:
 ## Bug/Defect Patch Report Template
 Here is an example Test Report starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment.
 
-<pre><code>== Test Report
+```
+== Test Report
 This report validates that the indicated patch addresses the issue.
 
 Patch tested: REPLACE_WITH_PATCH_URL
@@ -37,7 +38,8 @@ Patch tested: REPLACE_WITH_PATCH_URL
 === Supplemental Artifacts
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
-Add as Attachment</code></pre>
+Add as Attachment
+```
 
 If already provided in the ticket, Testing Instructions do not need to be duplicated in the Test Report.
 
@@ -46,7 +48,8 @@ Here is an example Test Report starter template, which can be copied and pasted 
 
 In the “Actual Results” section, list each of the “Expected Results” and report your findings using ✅ to indicate your testing validated it works as expected or ❌ to indicate it does not work as expected.
 
-<pre><code>== Test Report
+```
+== Test Report
 This report validates that the indicated patch addresses the issue.
 
 Patch tested: REPLACE_WITH_PATCH_URL
@@ -72,6 +75,7 @@ Patch tested: REPLACE_WITH_PATCH_URL
 === Supplemental Artifacts
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
-Add as Attachment</code></pre>
+Add as Attachment
+```
 
 If already provided in the ticket, Testing Instructions do not need to be duplicated in the Test Report.

--- a/test-reports/patch-testing.md
+++ b/test-reports/patch-testing.md
@@ -12,6 +12,8 @@ Example patch testing reports:
 ## Bug/Defect Patch Report Template
 Here is an example Test Report starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment.
 
+### For Trac (WikiFormatting)
+
 ```
 == Test Report
 This report validates that the indicated patch addresses the issue.
@@ -41,12 +43,43 @@ or
 Add as Attachment
 ```
 
+### For GitHub (Markdown)
+
+```markdown
+## Test Report
+This report validates that the indicated patch addresses the issue.
+
+Patch tested: REPLACE_WITH_PATCH_URL
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Actual Results
+- ✅ Issue resolved with patch.
+
+### Additional Notes
+- Any additional details worth mention.
+
+### Supplemental Artifacts
+![Image description](REPLACE_WITH_IMAGE_URL)
+```
+
 If already provided in the ticket, Testing Instructions do not need to be duplicated in the Test Report.
 
 ## Feature or Enhancement Patch Report Template
 Here is an example Test Report starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment.
 
 In the “Actual Results” section, list each of the “Expected Results” and report your findings using ✅ to indicate your testing validated it works as expected or ❌ to indicate it does not work as expected.
+
+### For Trac (WikiFormatting)
 
 ```
 == Test Report
@@ -76,6 +109,36 @@ Patch tested: REPLACE_WITH_PATCH_URL
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
 Add as Attachment
+```
+
+### For GitHub (Markdown)
+
+```markdown
+## Test Report
+This report validates that the indicated patch addresses the issue.
+
+Patch tested: REPLACE_WITH_PATCH_URL
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Actual Results
+- ✅ Expected result #1 works as expected with patch.
+- ✅ Expected result #2 works as expected with patch.
+
+### Additional Notes
+- Any additional details worth mention.
+
+### Supplemental Artifacts
+![Image description](REPLACE_WITH_IMAGE_URL)
 ```
 
 If already provided in the ticket, Testing Instructions do not need to be duplicated in the Test Report.

--- a/test-reports/testing-instructions.md
+++ b/test-reports/testing-instructions.md
@@ -15,7 +15,8 @@ An important first step in addressing a reported issue is to clearly communicate
 
 Here is an example Testing Instructions starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment:
 
-<pre><code>== Testing Instructions
+```
+== Testing Instructions
 These steps define how to reproduce the issue, and indicate the expected behavior.
 
 === Environment
@@ -44,14 +45,16 @@ When reproducing a bug:
 === Supplemental Artifacts
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
-Add as Attachment</code></pre>
+Add as Attachment
+```
 
 ## Feature or Enhancement Testing Instructions Template
 A new feature or enhancement (non-bug/defect) should identify the steps and instructions for how to validate the patch works and what the expected results or behaviors are (i.e. what should it do, meaning what should the tester be testing to verify it works).
 
 Here is an example Testing Instructions starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment:
 
-<pre><code>== Testing Instructions
+```
+== Testing Instructions
 These steps define how to test the feature or enhancement, and indicates the expected behavior or results.
 
 === Environment
@@ -80,4 +83,5 @@ Lists each expected result or behavior, i.e. what should happen when running the
 === Supplemental Artifacts
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
-Add as Attachment</code></pre>
+Add as Attachment
+```

--- a/test-reports/testing-instructions.md
+++ b/test-reports/testing-instructions.md
@@ -15,6 +15,8 @@ An important first step in addressing a reported issue is to clearly communicate
 
 Here is an example Testing Instructions starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment:
 
+### For Trac (WikiFormatting)
+
 ```
 == Testing Instructions
 These steps define how to reproduce the issue, and indicate the expected behavior.
@@ -48,10 +50,45 @@ or
 Add as Attachment
 ```
 
+### For GitHub (Markdown)
+
+```markdown
+## Testing Instructions
+These steps define how to reproduce the issue, and indicate the expected behavior.
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Steps to Reproduce
+1. First step.
+2. Second step.
+3. 🐞 Bug occurs.
+
+### Expected Results
+When testing a patch to validate it works as expected:
+- ✅ What should happen when running the test
+
+When reproducing a bug:
+- ❌ Error condition occurs.
+
+### Supplemental Artifacts
+![Image description](REPLACE_WITH_IMAGE_URL)
+```
+
 ## Feature or Enhancement Testing Instructions Template
 A new feature or enhancement (non-bug/defect) should identify the steps and instructions for how to validate the patch works and what the expected results or behaviors are (i.e. what should it do, meaning what should the tester be testing to verify it works).
 
 Here is an example Testing Instructions starter template, which can be copied and pasted directly into a text editor to prepare the report, and then added to Trac as a comment:
+
+### For Trac (WikiFormatting)
 
 ```
 == Testing Instructions
@@ -84,4 +121,37 @@ Lists each expected result or behavior, i.e. what should happen when running the
 Add Inline: [[Image(REPLACE_WITH_IMAGE_URL)]]
 or
 Add as Attachment
+```
+
+### For GitHub (Markdown)
+
+```markdown
+## Testing Instructions
+These steps define how to test the feature or enhancement, and indicates the expected behavior or results.
+
+### Environment
+- OS: Operating System X.Y.Z
+- Web Server: Server Name X.Y.Z
+- PHP: X.Y.Z
+- WordPress: X.Y-Z
+- Browser: Browser Name X.Y.Z
+- Theme: Theme Name X.Y.Z 
+- Active Plugins:
+  - Plugin 1 X.Y.Z
+  - Plugin 2 X.Y.Z
+
+### Steps to Test
+1. First step.
+2. Second step.
+3. Third step.
+...
+N. Last step.
+
+### Expected Results
+Lists each expected result or behavior, i.e. what should happen when running the test(s):
+- ✅ Expected result #1
+- ✅ Expected result #2
+
+### Supplemental Artifacts
+![Image description](REPLACE_WITH_IMAGE_URL)
 ```


### PR DESCRIPTION
## Summary
This PR adds Markdown template versions for GitHub alongside existing Trac WikiFormatting templates in the test report documentation pages.

## Related Issues
- Closes #3
- Related to #85

## Changes

### Test Report Templates
Added "For GitHub (Markdown)" sections with `##`/`###` heading syntax to:
- [test-reports/testing-instructions.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/test-handbook/test-reports/testing-instructions.md:0:0-0:0) (2 templates)
- [test-reports/issue-reproduction.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/test-handbook/test-reports/issue-reproduction.md:0:0-0:0) (1 template)
- [test-reports/patch-testing.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/test-handbook/test-reports/patch-testing.md:0:0-0:0) (2 templates)
- [test-reports/combined-report.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/test-handbook/test-reports/combined-report.md:0:0-0:0) (2 templates)

### Bug Fix
- Fixed malformed WordPress Playground link in [release-squad.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/test-handbook/release-squad.md:0:0-0:0)

## Testing
- Verified Markdown renders correctly in preview
- Confirmed templates can be easily copied for both Trac and GitHub