### PR TITLE
Test chat moderator guide

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -9,9 +9,16 @@
     "team-reps": {
         "title": "Test Team Reps",
         "slug": "team-reps",
-        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/team-reps.md",
+        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/team-reps\/index.md",
         "parent": null,
         "order": 10
+    },
+    "team-reps\/test-chat-moderator-guide": {
+        "title": "Test Chat Moderator Guide",
+        "slug": "test-chat-moderator-guide",
+        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/team-reps\/test-chat-moderator-guide.md",
+        "parent": "team-reps",
+        "order": 1
     },
     "get-setup-for-testing": {
         "title": "Get Setup for Testing",

--- a/team-reps/index.md
+++ b/team-reps/index.md
@@ -17,7 +17,7 @@ Test Team Rep duties include:
 - Write weekly [Test Team Update](https://make.wordpress.org/updates/tag/test/) posts, and post to [Team Updates](https://make.wordpress.org/updates/).
 - Write weekly [Week in Test](https://make.wordpress.org/test/category/week-in-test/) posts, and post to [Make WordPress Test](https://make.wordpress.org/test/).
 - Write agenda for bi-weekly `<test-chat>` sessions ([example](https://make.wordpress.org/test/2025/10/07/team-chat-agenda-8-october-2025/)).
-- Run alternating weekly `<test-chat>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759931984959659)) and `<patch-testing-scrub>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759417225194679)) sessions in [#core-test](https://wordpress.slack.com/messages/core-test/).
+- Run alternating weekly `<test-chat>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759931984959659)) and `<patch-testing-scrub>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759417225194679)) sessions in [#core-test](https://wordpress.slack.com/messages/core-test/). See the [Test Chat Moderator Guide](test-chat-moderator-guide.md) for detailed instructions.
 - Write `<test-chat>` session recaps, and post to [Make WordPress Test](https://make.wordpress.org/test/).
 - Help raise awareness for testing needs, especially for upcoming releases.
 - Raise issues or red flags that other teams should be aware of or discussing.

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -1,0 +1,409 @@
+# Test Chat Moderator Guide
+
+This guide helps moderators run Test Team Chat meetings. Use the structure and example phrases below as a reference.
+
+## Pre-Meeting Preparation
+
+Before the meeting:
+1. Review the [meeting agenda](https://make.wordpress.org/test/) published beforehand
+2. Prepare any links or resources mentioned in the agenda
+3. Have the Test Team Handbook open: https://github.com/WordPress/test-handbook
+4. Note the scheduled start and end time
+5. Be ready to take notes or delegate note-taking
+
+## Meeting Structure & Script
+
+### 1. Opening / Welcome (Start Time)
+
+**Announce meeting start:**
+```
+@aquí Hey everyone! Please join us in #core-test for this week's Test Team chat.
+```
+_Or:_
+```
+@aquí We are starting now today's <test-chat>
+```
+
+**Welcome message:**
+```
+Hello and welcome to this bi-weekly test team chat meeting!
+```
+
+### 2. Attendance Check
+
+**Request attendance:**
+```
+Who is joining us today? Please reply in the thread:
+1. Please say hello and note your WordPress.org profile username, as we will use this to record attendees in the notes.
+2. Feel welcome to introduce yourself briefly and share a flag or your favorite emoji!
+```
+
+**Note about async participation:**
+```
+If you're joining this chat **async**, please add your details to the thread later and include (async) after your name. This helps us review meeting times and encourage participation across all time zones.
+```
+
+### 3. Share Agenda
+
+**Link to agenda:**
+```
+Today's chat agenda can be found [here](LINK_TO_AGENDA). Please take a look.
+```
+
+**Example links:**
+- https://make.wordpress.org/test/2026/01/21/team-chat-agenda-22nd-january-2026/
+- https://make.wordpress.org/test/2026/01/14/team-chat-agenda-14th-january-2026/
+
+### 4. Meeting Notes Announcement
+
+**Declare meeting notes section:**
+```
+**Meeting Notes**
+```
+
+**Identify facilitator:**
+```
+Today's session facilitator and note-taker is **@[YOUR_USERNAME]**
+```
+
+### 5. Test Team Discussions
+
+**Transition to main agenda:**
+```
+Now let's move on to agenda item: **Test Team Discussions**
+```
+
+**For each agenda item:**
+
+**Introduce the item:**
+```
+- [AGENDA_ITEM_TITLE]
+```
+
+**Provide context (if needed):**
+```
+[Brief explanation or context about the topic]
+```
+
+**Facilitate discussion:**
+- Let participants share their thoughts
+- Ask clarifying questions when needed
+- Summarize key points
+- Acknowledge contributions
+
+**Example facilitator responses:**
+```
+Great @[USERNAME]! Is there any more context about this work? GitHub Issues? Scripts for the videos? Related discussions?
+```
+
+```
+Understood! 👍
+```
+
+```
+Just to confirm, [restate or clarify what was discussed]?
+```
+
+```
+Noted. I'll [summarize action items or next steps].
+```
+
+```
+Got it 👍 Thanks for the clarification.
+```
+
+```
+Thanks, @[USERNAME] 🙌 Appreciate the willingness to help.
+```
+
+**Transition between items:**
+```
+Then I think we can move to the next item in the agenda:
+- [NEXT_AGENDA_ITEM]
+```
+
+_Or:_
+```
+Perfect! I think we can now move on to the next item in the Agenda:
+- [NEXT_AGENDA_ITEM]
+```
+
+**When discussion needs continuation:**
+```
+Oks, the [TOPIC] require more thinking so we'll move the conversation to the GitHub Issue and bring it back to another weekly chat once there's more consensus on it.
+```
+
+```
+Let's continue the conversation in the GitHub Issue that I'll create and add to the meeting notes
+```
+
+**GitHub-related responses:**
+```
+Cool! So if anyone is up to opening such a PR, here's the repo:
+https://github.com/WordPress/test-handbook
+```
+
+**When wrapping up a discussion:**
+```
+Sounds good, We can discuss this on GitHub and make the required changes accordingly.
+```
+
+### 6. Open Floor
+
+**Time check (10 minutes before end):**
+```
+10min to end the meeting
+```
+
+**Transition to open floor:**
+```
+Let's move to the **Open Floor** 🎤
+```
+
+**Invite contributions:**
+```
+Does anyone have anything they'd like to share or discuss?
+```
+
+**If no responses:**
+- Wait a reasonable amount of time (1-2 minutes)
+- If still no responses, proceed to announcements
+
+### 7. Announcements
+
+**Transition to announcements:**
+```
+Oks, then, before we finish the meeting here you have a few links of relevant things that are happening in the WordPress Ecosystem and in the Test Team
+```
+
+_Or:_
+```
+Let's now move on to the next agenda item: **WordPress Ecosystem Announcements**
+```
+
+#### A. WordPress Ecosystem Announcements
+
+**Introduce section:**
+```
+**WordPress Ecosystem Announcements**
+```
+
+**List announcements with links:**
+```
+- [Title of Announcement](LINK)
+- [Title of Announcement](LINK)
+- [Title of Announcement](LINK)
+```
+
+**Example announcements to include:**
+- Gutenberg releases
+- WordPress version releases and schedules
+- PHP version support changes
+- Major release schedules
+- Developer news and resources
+- Core team calls for volunteers
+
+#### B. Test Team Announcements
+
+**Introduce section:**
+```
+**Test Team Announcements**
+```
+
+_Or:_
+```
+next move to **Test Team Announcements**:
+```
+
+**List Test Team specific items:**
+```
+- [Test Team Program Information](LINK)
+- [Week in Test Post](LINK): Brief description
+- [Test Team Update](LINK): Metrics for overall team progress
+```
+
+#### C. Call for Testing
+
+**Introduce section:**
+```
+**Call for Testing**
+```
+
+_Or:_
+```
+next **Call for Testing**
+```
+
+**List testing needs:**
+```
+- [Help Test WordPress X.X](LINK)
+- We have [Patch Testing Issues](LINK) that need testing
+```
+
+**Standard links:**
+- Core Patch Testing: https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&changetime=1weekago..&keywords=~needs-testing+has-patch
+- Gutenberg Issues: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
+
+**Check for reactions:**
+```
+Any comment about any of these resources?
+```
+
+### 8. Closing
+
+**When ready to close:**
+```
+As there are no more comments we can wrap up the meeting.
+```
+
+**Final closing message:**
+```
+So this bring us to the end of our meeting </test-chat> thank you all for coming.
+```
+
+_Alternative:_
+```
+And this bring us to the end of our meeting. Thank you all for coming.
+```
+
+## Moderator Tips
+
+### During Discussions
+
+**Acknowledge all participants** - Thank people for their contributions and use their @username when responding.
+
+**Ask clarifying questions** - "Just to confirm, [restate]?" or "Is there any more context about this work?" or "Could you elaborate on [topic]?"
+
+**Summarize and capture action items** - "Noted. I'll [action item]" or "Sounds good, we can [next step]"
+
+**Keep discussions on track** - Gently redirect off-topic discussions. Suggest moving lengthy debates to GitHub. Be mindful of time.
+
+**Facilitate, don't dominate** - Allow space for others to speak. Encourage quieter participants. Balance the conversation.
+
+### GitHub Integration
+
+When discussions need follow-up:
+- Suggest creating GitHub issues
+- Reference the test-handbook repo
+- Encourage PRs for concrete proposals
+- Link to existing issues when relevant
+
+**Common references:**
+- Test Handbook: https://github.com/WordPress/test-handbook
+- Test Handbook Issues: https://github.com/WordPress/test-handbook/issues
+
+### Time Management
+
+- **Start on time** (scheduled time)
+- **Typical meeting length:** 55-60 minutes
+- **10-minute warning:** Announce time before Open Floor
+- **End on time:** Respect participants' schedules
+
+### Note-Taking
+
+As facilitator, you should:
+- Capture key discussion points
+- Note action items and owners
+- Record decisions made
+- List attendees (from thread)
+- Prepare meeting summary for publication
+
+### Common Situations
+
+**If discussion gets detailed/technical:**
+```
+Discussions here in the test-chat are just to brainstorm a bit about the ideas. To formalize the conclusion we should be opening a ticket in GitHub to conclude the final details and not forget to do the thing 🙂
+```
+
+**If someone offers help:**
+```
+Thanks, @[USERNAME] 🙌 Appreciate the willingness to help.
+```
+
+**If clarification is needed:**
+```
+Just to confirm, [restate the point]?
+```
+
+**If moving to next topic:**
+```
+I think we can move to the next item in the agenda: [TOPIC]
+```
+
+## Post-Meeting Tasks
+
+After the meeting:
+1. Compile meeting notes from the discussion
+2. Create GitHub issues as mentioned during meeting
+3. Update calendar if schedule changes were discussed
+4. Publish summary to make.wordpress.org/test if required
+5. Follow up on action items assigned during meeting
+
+## Quick Reference - Meeting Flow
+
+```
+1. Opening & Welcome (2-3 min)
+2. Attendance Check (2 min)
+3. Share Agenda (1 min)
+4. Meeting Notes Declaration (1 min)
+5. Test Team Discussions (30-40 min)
+   - Multiple agenda items
+   - Facilitate discussion for each
+   - Transition between items
+6. Open Floor (5-10 min)
+7. Announcements (5-8 min)
+   - WordPress Ecosystem
+   - Test Team
+   - Call for Testing
+8. Closing (1-2 min)
+```
+
+**Total Duration:** ~55-60 minutes
+
+## Resources & Links
+
+### Essential Pages
+- Make Test: https://make.wordpress.org/test/
+- Test Handbook: https://github.com/WordPress/test-handbook
+- Test Handbook Issues: https://github.com/WordPress/test-handbook/issues
+- Core Reports: https://make.wordpress.org/core/reports/
+
+### Regular Reports
+- Week in Test: Published weekly at make.wordpress.org/test
+- Test Team Update: Bi-weekly metrics report
+- Gutenberg Releases: Bi-weekly release announcements
+
+### Testing Resources
+- Core Needs Testing: https://core.trac.wordpress.org/report/69
+- Gutenberg Needs Testing: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
+- Core Patch Testing: https://core.trac.wordpress.org/query?keywords=~needs-testing+has-patch
+
+## Example Full Opening Sequence
+
+```
+[14:02] Moderator: @aquí Hey everyone! Please join us in #core-test for this week's Test Team chat.
+
+[14:02] Moderator: Hello and welcome to this bi-weekly test team chat meeting!
+
+[14:02] Moderator: Who is joining us today? Please reply in the thread:
+1. Please say hello and note your WordPress.org profile username, as we will use this to record attendees in the notes.
+2. Feel welcome to introduce yourself briefly and share a flag or your favorite emoji!
+
+[14:05] Moderator: If you're joining this chat **async**, please add your details to the thread later and include (async) after your name. This helps us review meeting times and encourage participation across all time zones.
+
+[14:06] Moderator: Today's chat agenda can be found [here](LINK). Please take a look.
+
+[14:07] Moderator: **Meeting Notes**
+
+[14:08] Moderator: Today's session facilitator and note-taker is **@YourUsername**
+
+[14:10] Moderator: Now let's move on to agenda item: **Test Team Discussions**
+
+[14:10] Moderator: - [First Agenda Item]
+```
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** January 2026
+**Based on:** Test Team Chat meetings from January 14 & 22, 2026

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -401,9 +401,3 @@ After the meeting:
 
 [14:10] Moderator: - [First Agenda Item]
 ```
-
----
-
-**Document Version:** 1.0
-**Last Updated:** January 2026
-**Based on:** Test Team Chat meetings from January 14 & 22, 2026

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -273,8 +273,8 @@ After the meeting:
 - Core Reports: https://make.wordpress.org/core/reports/
 
 ### Regular Reports
-- Week in Test: Published weekly at make.wordpress.org/test
-- Test Team Update: Bi-weekly metrics report
+- Month in Test: Published monthly at make.wordpress.org/test
+- Test Team Update: Weekly metrics report
 - Gutenberg Releases: Bi-weekly release announcements
 
 ### Testing Resources

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -55,6 +55,20 @@ _Or:_
 **Identify facilitator:**
 > Today's session facilitator and note-taker is **@[YOUR_USERNAME]**
 
+_Or, if the roles are handled by different people:_
+> Today's session facilitator is **@[FACILITATOR_USERNAME]** and the note-taker is **@[NOTE_TAKER_USERNAME]**
+
+**Upcoming 4-Week Schedule (Optional):**
+
+> 📅 **Upcoming 4-Week Schedule**
+>
+> * 12 February 2026 – Facilitator: @username1 | Note-taker: @username2
+> * 26 February 2026 – Facilitator: @username3 | Note-taker: @username4
+> * 12 March 2026 – Facilitator: (Open) | Note-taker: (Open)
+> * 26 March 2026 – Facilitator: (Open) | Note-taker: (Open)
+>
+> 🙌 If you'd like to volunteer for any open slot, please reply in the thread.
+
 ### 5. Test Team Discussions
 
 **Transition to main agenda:**
@@ -151,7 +165,7 @@ _Or:_
 > - We have [Patch Testing Issues](LINK) that need testing
 
 **Standard links:**
-- Core Needs Testing: https://core.trac.wordpress.org/report/69
+- Core Needs Testing: https://core.trac.wordpress.org/tickets/needs-testing (this report is slated to be deprecated and removed)
 - Gutenberg Needs Testing: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
 
 **Check for reactions:**
@@ -252,14 +266,14 @@ After the meeting:
 3. Share Agenda (1 min)
 4. Meeting Notes Declaration (1 min)
 5. Test Team Discussions (30-40 min)
-   - Multiple agenda items
-   - Facilitate discussion for each
-   - Transition between items
+   1. Multiple agenda items
+   2. Facilitate discussion for each
+   3. Transition between items
 6. Open Floor (5-10 min)
 7. Announcements (5-8 min)
-   - WordPress Ecosystem
-   - Test Team
-   - Call for Testing
+   1. WordPress Ecosystem
+   2. Test Team
+   3. Call for Testing
 8. Closing (1-2 min)
 
 **Total Duration:** ~55-60 minutes

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -22,7 +22,7 @@ _Or:_
 > /here We are starting now today's <test-chat>
 
 <div class="callout callout-info">
-<code>@here</code> notifies only active/online members in the channel.
+<code>/here</code> notifies only active/online members in the channel.
 </div>
 
 **Welcome message:**
@@ -293,7 +293,7 @@ After the meeting:
 
 ## Example Full Opening Sequence
 
-> [14:02] Moderator: @here Hey everyone! Please join us in #core-test for this week's Test Team chat.
+> [14:02] Moderator: /here Hey everyone! Please join us in #core-test for this week's Test Team chat.
 >
 > [14:02] Moderator: Hello and welcome to this bi-weekly test team chat meeting!
 >

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -16,39 +16,32 @@ Before the meeting:
 ### 1. Opening / Welcome (Start Time)
 
 **Announce meeting start:**
-```
-@aquí Hey everyone! Please join us in #core-test for this week's Test Team chat.
-```
+> @here Hey everyone! Please join us in #core-test for this week's Test Team chat.
+
 _Or:_
-```
-@aquí We are starting now today's <test-chat>
-```
+> @here We are starting now today's <test-chat>
+
+<div class="callout callout-info">
+<code>@here</code> notifies only active/online members in the channel.
+</div>
 
 **Welcome message:**
-```
-Hello and welcome to this bi-weekly test team chat meeting!
-```
+> Hello and welcome to this bi-weekly test team chat meeting!
 
 ### 2. Attendance Check
 
 **Request attendance:**
-```
-Who is joining us today? Please reply in the thread:
-1. Please say hello and note your WordPress.org profile username, as we will use this to record attendees in the notes.
-2. Feel welcome to introduce yourself briefly and share a flag or your favorite emoji!
-```
+> Who is joining us today? Please reply in the thread:
+> 1. Please say hello and note your WordPress.org profile username, as we will use this to record attendees in the notes.
+> 2. Feel welcome to introduce yourself briefly and share a flag or your favorite emoji!
 
 **Note about async participation:**
-```
-If you're joining this chat **async**, please add your details to the thread later and include (async) after your name. This helps us review meeting times and encourage participation across all time zones.
-```
+> If you're joining this chat **async**, please add your details to the thread later and include (async) after your name. This helps us review meeting times and encourage participation across all time zones.
 
 ### 3. Share Agenda
 
 **Link to agenda:**
-```
-Today's chat agenda can be found [here](LINK_TO_AGENDA). Please take a look.
-```
+> Today's chat agenda can be found [here](LINK_TO_AGENDA). Please take a look.
 
 **Example links:**
 - https://make.wordpress.org/test/2026/01/21/team-chat-agenda-22nd-january-2026/
@@ -57,33 +50,23 @@ Today's chat agenda can be found [here](LINK_TO_AGENDA). Please take a look.
 ### 4. Meeting Notes Announcement
 
 **Declare meeting notes section:**
-```
-**Meeting Notes**
-```
+> **Meeting Notes**
 
 **Identify facilitator:**
-```
-Today's session facilitator and note-taker is **@[YOUR_USERNAME]**
-```
+> Today's session facilitator and note-taker is **@[YOUR_USERNAME]**
 
 ### 5. Test Team Discussions
 
 **Transition to main agenda:**
-```
-Now let's move on to agenda item: **Test Team Discussions**
-```
+> Now let's move on to agenda item: **Test Team Discussions**
 
 **For each agenda item:**
 
 **Introduce the item:**
-```
-- [AGENDA_ITEM_TITLE]
-```
+> - [AGENDA_ITEM_TITLE]
 
 **Provide context (if needed):**
-```
-[Brief explanation or context about the topic]
-```
+> [Brief explanation or context about the topic]
 
 **Facilitate discussion:**
 - Let participants share their thoughts
@@ -91,79 +74,26 @@ Now let's move on to agenda item: **Test Team Discussions**
 - Summarize key points
 - Acknowledge contributions
 
-**Example facilitator responses:**
-```
-Great @[USERNAME]! Is there any more context about this work? GitHub Issues? Scripts for the videos? Related discussions?
-```
-
-```
-Understood! 👍
-```
-
-```
-Just to confirm, [restate or clarify what was discussed]?
-```
-
-```
-Noted. I'll [summarize action items or next steps].
-```
-
-```
-Got it 👍 Thanks for the clarification.
-```
-
-```
-Thanks, @[USERNAME] 🙌 Appreciate the willingness to help.
-```
-
 **Transition between items:**
-```
-Then I think we can move to the next item in the agenda:
-- [NEXT_AGENDA_ITEM]
-```
-
-_Or:_
-```
-Perfect! I think we can now move on to the next item in the Agenda:
-- [NEXT_AGENDA_ITEM]
-```
+> Then I think we can move to the next item in the agenda:
+> - [NEXT_AGENDA_ITEM]
 
 **When discussion needs continuation:**
-```
-Oks, the [TOPIC] require more thinking so we'll move the conversation to the GitHub Issue and bring it back to another weekly chat once there's more consensus on it.
-```
-
-```
-Let's continue the conversation in the GitHub Issue that I'll create and add to the meeting notes
-```
-
-**GitHub-related responses:**
-```
-Cool! So if anyone is up to opening such a PR, here's the repo:
-https://github.com/WordPress/test-handbook
-```
+> Let's continue the conversation in the GitHub Issue and bring it back to another chat once there's more consensus on it.
 
 **When wrapping up a discussion:**
-```
-Sounds good, We can discuss this on GitHub and make the required changes accordingly.
-```
+> We can discuss this on GitHub and make the required changes accordingly.
 
 ### 6. Open Floor
 
 **Time check (10 minutes before end):**
-```
-10min to end the meeting
-```
+> 10min to end the meeting
 
 **Transition to open floor:**
-```
-Let's move to the **Open Floor** 🎤
-```
+> Let's move to the **Open Floor**
 
 **Invite contributions:**
-```
-Does anyone have anything they'd like to share or discuss?
-```
+> Does anyone have anything they'd like to share or discuss?
 
 **If no responses:**
 - Wait a reasonable amount of time (1-2 minutes)
@@ -172,28 +102,20 @@ Does anyone have anything they'd like to share or discuss?
 ### 7. Announcements
 
 **Transition to announcements:**
-```
-Oks, then, before we finish the meeting here you have a few links of relevant things that are happening in the WordPress Ecosystem and in the Test Team
-```
+> Before we finish the meeting here you have a few links of relevant things that are happening in the WordPress Ecosystem and in the Test Team
 
 _Or:_
-```
-Let's now move on to the next agenda item: **WordPress Ecosystem Announcements**
-```
+> Let's now move on to the next agenda item: **WordPress Ecosystem Announcements**
 
 #### A. WordPress Ecosystem Announcements
 
 **Introduce section:**
-```
-**WordPress Ecosystem Announcements**
-```
+> **WordPress Ecosystem Announcements**
 
 **List announcements with links:**
-```
-- [Title of Announcement](LINK)
-- [Title of Announcement](LINK)
-- [Title of Announcement](LINK)
-```
+> - [Title of Announcement](LINK)
+> - [Title of Announcement](LINK)
+> - [Title of Announcement](LINK)
 
 **Example announcements to include:**
 - Gutenberg releases
@@ -206,79 +128,59 @@ Let's now move on to the next agenda item: **WordPress Ecosystem Announcements**
 #### B. Test Team Announcements
 
 **Introduce section:**
-```
-**Test Team Announcements**
-```
+> **Test Team Announcements**
 
 _Or:_
-```
-next move to **Test Team Announcements**:
-```
+> next move to **Test Team Announcements**:
 
 **List Test Team specific items:**
-```
-- [Test Team Program Information](LINK)
-- [Week in Test Post](LINK): Brief description
-- [Test Team Update](LINK): Metrics for overall team progress
-```
+> - [Test Team Program Information](LINK)
+> - [Week in Test Post](LINK): Brief description
+> - [Test Team Update](LINK): Metrics for overall team progress
 
 #### C. Call for Testing
 
 **Introduce section:**
-```
-**Call for Testing**
-```
+> **Call for Testing**
 
 _Or:_
-```
-next **Call for Testing**
-```
+> next **Call for Testing**
 
 **List testing needs:**
-```
-- [Help Test WordPress X.X](LINK)
-- We have [Patch Testing Issues](LINK) that need testing
-```
+> - [Help Test WordPress X.X](LINK)
+> - We have [Patch Testing Issues](LINK) that need testing
 
 **Standard links:**
 - Core Patch Testing: https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&changetime=1weekago..&keywords=~needs-testing+has-patch
 - Gutenberg Issues: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
 
 **Check for reactions:**
-```
-Any comment about any of these resources?
-```
+> Any comment about any of these resources?
 
 ### 8. Closing
 
 **When ready to close:**
-```
-As there are no more comments we can wrap up the meeting.
-```
+> As there are no more comments we can wrap up the meeting.
 
 **Final closing message:**
-```
-So this bring us to the end of our meeting </test-chat> thank you all for coming.
-```
+> So this bring us to the end of our meeting </test-chat> thank you all for coming.
 
 _Alternative:_
-```
-And this bring us to the end of our meeting. Thank you all for coming.
-```
+> And this bring us to the end of our meeting. Thank you all for coming.
 
 ## Moderator Tips
 
 ### During Discussions
 
-**Acknowledge all participants** - Thank people for their contributions and use their @username when responding.
+- **Acknowledge all participants** - Thank people for their contributions and use their @username when responding.
 
-**Ask clarifying questions** - "Just to confirm, [restate]?" or "Is there any more context about this work?" or "Could you elaborate on [topic]?"
+- **Ask clarifying questions** - "Just to confirm, [restate]?" or "Is there any more context about this work?" or "Could you elaborate on [topic]?"
 
-**Summarize and capture action items** - "Noted. I'll [action item]" or "Sounds good, we can [next step]"
+- **Summarize and capture action items** - "Noted. I'll [action item]" or "Sounds good, we can [next step]"
 
-**Keep discussions on track** - Gently redirect off-topic discussions. Suggest moving lengthy debates to GitHub. Be mindful of time.
+- **Keep discussions on track** - Gently redirect off-topic discussions. Suggest moving lengthy debates to GitHub. Be mindful of time.
 
-**Facilitate, don't dominate** - Allow space for others to speak. Encourage quieter participants. Balance the conversation.
+- **Facilitate, don't dominate** - Allow space for others to speak. Encourage quieter participants. Balance the conversation.
 
 ### GitHub Integration
 
@@ -308,27 +210,31 @@ As facilitator, you should:
 - List attendees (from thread)
 - Prepare meeting summary for publication
 
+<div class="callout callout-tip">
+Since meetings are conducted asynchronously in Slack, you can copy the entire meeting transcript and paste it into an AI client to help process and summarize the key points, action items, and decisions for publication.
+</div>
+
 ### Common Situations
 
 **If discussion gets detailed/technical:**
-```
-Discussions here in the test-chat are just to brainstorm a bit about the ideas. To formalize the conclusion we should be opening a ticket in GitHub to conclude the final details and not forget to do the thing 🙂
-```
+- Suggest moving detailed discussions to GitHub issues
+- Remind participants that chat is for brainstorming, GitHub is for finalizing details
+- Offer to create a GitHub issue to track the conversation
 
 **If someone offers help:**
-```
-Thanks, @[USERNAME] 🙌 Appreciate the willingness to help.
-```
+- Acknowledge their willingness to contribute
+- Note their offer in the meeting notes
+- Provide relevant links or resources they might need
 
 **If clarification is needed:**
-```
-Just to confirm, [restate the point]?
-```
+- Ask clarifying questions
+- Restate the point to confirm understanding
+- Summarize the discussion so far
 
 **If moving to next topic:**
-```
-I think we can move to the next item in the agenda: [TOPIC]
-```
+- Announce the transition
+- Briefly reference the next agenda item
+- Allow a moment for any final comments
 
 ## Post-Meeting Tasks
 
@@ -341,22 +247,20 @@ After the meeting:
 
 ## Quick Reference - Meeting Flow
 
-```
-1. Opening & Welcome (2-3 min)
-2. Attendance Check (2 min)
-3. Share Agenda (1 min)
-4. Meeting Notes Declaration (1 min)
-5. Test Team Discussions (30-40 min)
-   - Multiple agenda items
-   - Facilitate discussion for each
-   - Transition between items
-6. Open Floor (5-10 min)
-7. Announcements (5-8 min)
-   - WordPress Ecosystem
-   - Test Team
-   - Call for Testing
-8. Closing (1-2 min)
-```
+> 1. Opening & Welcome (2-3 min)
+> 2. Attendance Check (2 min)
+> 3. Share Agenda (1 min)
+> 4. Meeting Notes Declaration (1 min)
+> 5. Test Team Discussions (30-40 min)
+>    - Multiple agenda items
+>    - Facilitate discussion for each
+>    - Transition between items
+> 6. Open Floor (5-10 min)
+> 7. Announcements (5-8 min)
+>    - WordPress Ecosystem
+>    - Test Team
+>    - Call for Testing
+> 8. Closing (1-2 min)
 
 **Total Duration:** ~55-60 minutes
 
@@ -380,24 +284,22 @@ After the meeting:
 
 ## Example Full Opening Sequence
 
-```
-[14:02] Moderator: @aquí Hey everyone! Please join us in #core-test for this week's Test Team chat.
-
-[14:02] Moderator: Hello and welcome to this bi-weekly test team chat meeting!
-
-[14:02] Moderator: Who is joining us today? Please reply in the thread:
-1. Please say hello and note your WordPress.org profile username, as we will use this to record attendees in the notes.
-2. Feel welcome to introduce yourself briefly and share a flag or your favorite emoji!
-
-[14:05] Moderator: If you're joining this chat **async**, please add your details to the thread later and include (async) after your name. This helps us review meeting times and encourage participation across all time zones.
-
-[14:06] Moderator: Today's chat agenda can be found [here](LINK). Please take a look.
-
-[14:07] Moderator: **Meeting Notes**
-
-[14:08] Moderator: Today's session facilitator and note-taker is **@YourUsername**
-
-[14:10] Moderator: Now let's move on to agenda item: **Test Team Discussions**
-
-[14:10] Moderator: - [First Agenda Item]
-```
+> [14:02] Moderator: @here Hey everyone! Please join us in #core-test for this week's Test Team chat.
+>
+> [14:02] Moderator: Hello and welcome to this bi-weekly test team chat meeting!
+>
+> [14:02] Moderator: Who is joining us today? Please reply in the thread:
+> 1. Please say hello and note your WordPress.org profile username, as we will use this to record attendees in the notes.
+> 2. Feel welcome to introduce yourself briefly and share a flag or your favorite emoji!
+>
+> [14:05] Moderator: If you're joining this chat **async**, please add your details to the thread later and include (async) after your name. This helps us review meeting times and encourage participation across all time zones.
+>
+> [14:06] Moderator: Today's chat agenda can be found [here](LINK). Please take a look.
+>
+> [14:07] Moderator: **Meeting Notes**
+>
+> [14:08] Moderator: Today's session facilitator and note-taker is **@YourUsername**
+>
+> [14:10] Moderator: Now let's move on to agenda item: **Test Team Discussions**
+>
+> [14:10] Moderator: - [First Agenda Item]

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -16,10 +16,10 @@ Before the meeting:
 ### 1. Opening / Welcome (Start Time)
 
 **Announce meeting start:**
-> @here Hey everyone! Please join us in #core-test for this week's Test Team chat.
+> /here Hey everyone! Please join us in #core-test for this week's Test Team chat.
 
 _Or:_
-> @here We are starting now today's <test-chat>
+> /here We are starting now today's <test-chat>
 
 <div class="callout callout-info">
 <code>@here</code> notifies only active/online members in the channel.
@@ -151,8 +151,8 @@ _Or:_
 > - We have [Patch Testing Issues](LINK) that need testing
 
 **Standard links:**
-- Core Patch Testing: https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&changetime=1weekago..&keywords=~needs-testing+has-patch
-- Gutenberg Issues: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
+- Core Needs Testing: https://core.trac.wordpress.org/report/69
+- Gutenberg Needs Testing: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
 
 **Check for reactions:**
 > Any comment about any of these resources?
@@ -247,20 +247,20 @@ After the meeting:
 
 ## Quick Reference - Meeting Flow
 
-> 1. Opening & Welcome (2-3 min)
-> 2. Attendance Check (2 min)
-> 3. Share Agenda (1 min)
-> 4. Meeting Notes Declaration (1 min)
-> 5. Test Team Discussions (30-40 min)
->    - Multiple agenda items
->    - Facilitate discussion for each
->    - Transition between items
-> 6. Open Floor (5-10 min)
-> 7. Announcements (5-8 min)
->    - WordPress Ecosystem
->    - Test Team
->    - Call for Testing
-> 8. Closing (1-2 min)
+1. Opening & Welcome (2-3 min)
+2. Attendance Check (2 min)
+3. Share Agenda (1 min)
+4. Meeting Notes Declaration (1 min)
+5. Test Team Discussions (30-40 min)
+   - Multiple agenda items
+   - Facilitate discussion for each
+   - Transition between items
+6. Open Floor (5-10 min)
+7. Announcements (5-8 min)
+   - WordPress Ecosystem
+   - Test Team
+   - Call for Testing
+8. Closing (1-2 min)
 
 **Total Duration:** ~55-60 minutes
 
@@ -276,11 +276,6 @@ After the meeting:
 - Month in Test: Published monthly at make.wordpress.org/test
 - Test Team Update: Weekly metrics report
 - Gutenberg Releases: Bi-weekly release announcements
-
-### Testing Resources
-- Core Needs Testing: https://core.trac.wordpress.org/report/69
-- Gutenberg Needs Testing: https://github.com/WordPress/gutenberg/issues?q=state%3Aopen%20label%3A%22Needs%20Testing%22
-- Core Patch Testing: https://core.trac.wordpress.org/query?keywords=~needs-testing+has-patch
 
 ## Example Full Opening Sequence
 


### PR DESCRIPTION
Partially addresses #11

This PR adds a comprehensive moderator guide for running `<test-chat>` meetings, based on actual Test Team Chat 
sessions from January 14 and January 22, 2026.

It only addresses the `<test-chat>` portion of issue #11. Guidelines for `<test-triage>` meetings remain to be documented in a future PR.

### Changes

**New Documentation:**
- Added `team-reps/test-chat-moderator-guide.md` with detailed instructions for moderators

**Restructuring:**
- Converted `team-reps.md` to a directory structure (`team-reps/index.md`)
- Added the moderator guide as a child page under Team Reps
- Updated `bin/handbook-manifest.json` to reflect the new structure
- Added reference link in team-reps duties section

### What's Included

The Test Chat Moderator Guide covers:

- **Pre-meeting preparation** checklist
- **Step-by-step meeting structure** with 8 sections:
  1. Opening/Welcome
  2. Attendance Check
  3. Share Agenda
  4. Meeting Notes Announcement
  5. Test Team Discussions
  6. Open Floor
  7. Announcements (Ecosystem, Test Team, Call for Testing)
  8. Closing
- **Example phrases** extracted from actual meetings for each section
- **Moderator tips** for facilitating discussions, GitHub integration, and time management
- **Common situations** with suggested responses
- **Post-meeting tasks** checklist
- **Quick reference** for meeting flow with timing
- **Resources and links** section
- **Full example** opening sequence