### PR TITLE
Add testing environment and Grunt testing documentation

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -20,12 +20,33 @@
         "parent": null,
         "order": 20
     },
+    "get-setup-for-testing\/set-up-a-testing-environment": {
+        "title": "Set Up a Testing Environment",
+        "slug": "set-up-a-testing-environment",
+        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/get-setup-for-testing\/set-up-a-testing-environment.md",
+        "parent": "get-setup-for-testing",
+        "order": 1
+    },
     "get-setup-for-testing\/test-core-tickets-with-playground": {
         "title": "Test Core Tickets with Playground",
         "slug": "test-core-tickets-with-playground",
         "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/get-setup-for-testing\/test-core-tickets-with-playground.md",
         "parent": "get-setup-for-testing",
-        "order": 1
+        "order": 2
+    },
+    "get-setup-for-testing\/test-core-tickets-with-grunt": {
+        "title": "Test Core Tickets with Grunt",
+        "slug": "test-core-tickets-with-grunt",
+        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/get-setup-for-testing\/test-core-tickets-with-grunt.md",
+        "parent": "get-setup-for-testing",
+        "order": 3
+    },
+    "get-setup-for-testing\/run-automated-tests": {
+        "title": "Run Automated Tests",
+        "slug": "run-automated-tests",
+        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/get-setup-for-testing\/run-automated-tests.md",
+        "parent": "get-setup-for-testing",
+        "order": 4
     },
     "test-reports": {
         "title": "Test Reports",

--- a/get-setup-for-testing/run-automated-tests.md
+++ b/get-setup-for-testing/run-automated-tests.md
@@ -37,7 +37,18 @@ npm run test:e2e
 ```
 
 ## Troubleshooting
-If you encounter errors, ensure your local environment is running:
-```bash
-npm run env:start
-```
+
+### "Error: ECONNREFUSED"
+- **Cause:** The local environment or Docker is not running.
+- **Fix:** Start Docker Desktop and run:
+  ```bash
+  npm run env:start
+  ```
+
+### "Database connection failed"
+- **Cause:** The database container isn't ready or needs to be reset.
+- **Fix:** Wait a few seconds and try again, or reset the environment:
+  ```bash
+  npm run env:reset
+  npm run env:install
+  ```

--- a/get-setup-for-testing/run-automated-tests.md
+++ b/get-setup-for-testing/run-automated-tests.md
@@ -1,0 +1,43 @@
+# Run Automated Tests
+
+Automated tests are crucial for ensuring that changes to WordPress core do not introduce regressions. This guide covers how to run the PHP and End-to-End (E2E) test suites locally.
+
+## Prerequisites
+Ensure a local testing environment is set up. See [Set Up a Testing Environment](https://make.wordpress.org/test/handbook/get-setup-for-testing/set-up-a-testing-environment/).
+
+To learn how to apply patches before running tests, see [Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/).
+
+## Run PHP Tests (PHPUnit)
+
+The PHP unit tests cover the backend PHP code of WordPress.
+
+To run the full PHPUnit test suite:
+```bash
+npm run test:php
+```
+
+### Running Specific Tests
+To run a specific group of tests (often related to a specific Trac ticket, if tagged):
+```bash
+npm run test:php -- --group 27307
+```
+
+To run tests within a specific class or file (filter):
+```bash
+npm run test:php -- --filter WP_Test_User_Query
+```
+
+## Run End-to-End (E2E) Tests
+
+E2E tests verify the behavior of the application from the user's perspective, running in a browser environment.
+
+To run the end-to-end test suite:
+```bash
+npm run test:e2e
+```
+
+## Troubleshooting
+If you encounter errors, ensure your local environment is running:
+```bash
+npm run env:start
+```

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -85,3 +85,6 @@ Your local WordPress site should now be accessible at `http://localhost:8889`.
 Now that your local environment is set up, learn how to apply patches and run tests:
 
 *   [Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/)
+
+## Resources
+- [WPContrib WordPress Test Contributor Pathway YouTube Channel](https://www.youtube.com/@WPContrib) by [@SirLouen](https://profiles.wordpress.org/sirlouen/)

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -1,0 +1,84 @@
+# Set Up a Testing Environment
+
+To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. This guide covers the options available for setting up a testing environment.
+
+## Choose Your Environment
+
+There are two main ways to test WordPress core tickets:
+
+1.  **WordPress Playground (Browser-based):** Best for quick visual testing and verifying patches without installing anything on your computer.
+2.  **Local Development Environment:** Required for more advanced testing, running automated tests (PHPUnit, e2e), and working with complex patches or build tools.
+
+### When to use Playground?
+- You need to quickly verify a visual change or a bug fix.
+- You cannot or do not want to install software on your computer.
+- The ticket has a Pull Request (PR) or a ZIP file that Playground can load.
+
+[Learn how to use Playground for testing](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-playground/)
+
+### When to use a Local Environment?
+- You need to use command-line tools like `grunt` or `git`.
+- You want to run automated test suites (PHPUnit, end-to-end tests).
+- You are developing a patch or working on a complex feature that requires a persistent environment.
+
+## Setting Up a Local Environment
+
+The recommended way to set up a local environment for WordPress core development is using **Docker**.
+
+### Prerequisites
+Before you begin, ensure you have the following installed on your computer:
+1.  **Node.js**: Version 20.x or later.
+2.  **npm**: Version 10.x or later (usually comes with Node.js).
+3.  **Git**: For version control.
+4.  **Docker Desktop** (or a compatible container runtime like OrbStack, Colima, or Rancher Desktop).
+
+### Setup Instructions
+
+1.  **Fork and Clone the Repository**
+    Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
+    ```bash
+    git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
+    cd wordpress-develop
+    ```
+
+2.  **Install Dependencies**
+    Run the following command to install the necessary JavaScript and PHP tools:
+    ```bash
+    npm install
+    ```
+
+3.  **Build WordPress**
+    Compile the source files into a running WordPress instance:
+    ```bash
+    npm run build:dev
+    ```
+
+4.  **Start the Environment**
+    Start the Docker environment:
+    ```bash
+    npm run env:start
+    ```
+
+5.  **Install WordPress**
+    Run the installation script to set up the database and site:
+    ```bash
+    npm run env:install
+    ```
+
+Your local WordPress site should now be accessible at `http://localhost:8889`.
+
+- **Username:** `admin`
+- **Password:** `password`
+
+### Common Commands
+
+-   **Start environment:** `npm run env:start`
+-   **Stop environment:** `npm run env:stop`
+-   **Reset environment:** `npm run env:reset` (Warning: deletes database)
+-   **Run WP-CLI commands:** `npm run env:cli -- <command>` (e.g., `npm run env:cli -- user list`)
+
+## Next Steps
+
+Now that your local environment is set up, learn how to apply patches and run tests:
+
+*   [Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/)

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -34,6 +34,9 @@ Before you begin, ensure you have the following installed on your computer:
 
 ### Setup Instructions
 
+**Prefer a video walkthrough?**\
+Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
+
 1.  **Fork and Clone the Repository**
     Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -37,8 +37,7 @@ Before you begin, ensure you have the following installed on your computer:
 **Prefer a video walkthrough?**\
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
-1.  **Fork and Clone the Repository**
-    Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
+1.  **Fork and Clone the Repository:** Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
     cd wordpress-develop
@@ -46,26 +45,22 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
     Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
-2.  **Install Dependencies**
-    Run the following command to install the necessary JavaScript and PHP tools:
+2.  **Install Dependencies:** Run the following command to install the necessary JavaScript and PHP tools:
     ```bash
     npm install
     ```
 
-3.  **Build WordPress**
-    Compile the source files into a running WordPress instance:
+3.  **Build WordPress:** Compile the source files into a running WordPress instance:
     ```bash
     npm run build:dev
     ```
 
-4.  **Start the Environment**
-    Ensure Docker Desktop is running, then start the Docker environment:
+4.  **Start the Environment:** Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start
     ```
 
-5.  **Install WordPress**
-    Run the installation script to set up the database and site:
+5.  **Install WordPress:** Run the installation script to set up the database and site:
     ```bash
     npm run env:install
     ```

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -1,6 +1,6 @@
 # Set Up a Testing Environment
 
-To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. This guide covers the options available for setting up a testing environment.
+To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. **Patches are created against the [`trunk`](https://github.com/WordPress/wordpress-develop) branch**, the development version of WordPress, not the stable release from wordpress.org/download, so you'll need to work with the development codebase. This guide covers the options available for setting up a testing environment.
 
 ## Choose Your Environment
 

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -37,7 +37,8 @@ Before you begin, ensure you have the following installed on your computer:
 **Prefer a video walkthrough?**\
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
-1.  **Fork and Clone the Repository:** Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
+1.  **Fork and Clone the Repository**\
+    Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
     cd wordpress-develop
@@ -45,22 +46,26 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
     Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
-2.  **Install Dependencies:** Run the following command to install the necessary JavaScript and PHP tools:
+2.  **Install Dependencies**\
+    Run the following command to install the necessary JavaScript and PHP tools:
     ```bash
     npm install
     ```
 
-3.  **Build WordPress:** Compile the source files into a running WordPress instance:
+3.  **Build WordPress**\
+    Compile the source files into a running WordPress instance:
     ```bash
     npm run build:dev
     ```
 
-4.  **Start the Environment:** Ensure Docker Desktop is running, then start the Docker environment:
+4.  **Start the Environment**\
+    Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start
     ```
 
-5.  **Install WordPress:** Run the installation script to set up the database and site:
+5.  **Install WordPress**\
+    Run the installation script to set up the database and site:
     ```bash
     npm run env:install
     ```

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -42,7 +42,9 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
     cd wordpress-develop
+    git remote add upstream https://github.com/WordPress/wordpress-develop.git
     ```
+    Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
 2.  **Install Dependencies**
     Run the following command to install the necessary JavaScript and PHP tools:
@@ -57,7 +59,7 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
 
 4.  **Start the Environment**
-    Start the Docker environment:
+    Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start
     ```

--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -12,7 +12,7 @@ Grunt is a JavaScript-based task runner that WordPress uses to automate developm
 The most common task for testers is applying a patch from a Trac ticket to your local environment.
 
 ### 1. Find the Ticket or Patch ID
-Go to [Core Trac](https://core.trac.wordpress.org/) and find the ticket you want to test.
+Go to [Needs Patch Testing in Core Trac](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&keywords=~needs-testing+has-patch&focuses=!docs&col=id&col=summary&col=focuses&col=keywords&col=owner&col=type&col=priority&col=changetime&order=changetime) and find the ticket you want to test.
 - Ideally, identify the **Ticket ID** (e.g., `27307`).
 - Or, find the specific **Patch URL** (e.g., `https://core.trac.wordpress.org/attachment/ticket/27307/27307.diff`).
 

--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -1,0 +1,87 @@
+# Test Core Tickets with Grunt
+
+Grunt is a JavaScript-based task runner that WordPress uses to automate development tasks. This guide assumes you have already [set up a local testing environment](https://make.wordpress.org/test/handbook/get-setup-for-testing/set-up-a-testing-environment/).
+
+## Why use Grunt?
+- To apply patches from Trac tickets easily.
+- To build the WordPress core files after changes.
+- To run automated tests.
+
+## Applying Patches
+
+The most common task for testers is applying a patch from a Trac ticket to your local environment.
+
+### 1. Find the Ticket or Patch ID
+Go to [Core Trac](https://core.trac.wordpress.org/) and find the ticket you want to test.
+- Ideally, identify the **Ticket ID** (e.g., `27307`).
+- Or, find the specific **Patch URL** (e.g., `https://core.trac.wordpress.org/attachment/ticket/27307/27307.diff`).
+
+### 2. Apply the Patch
+In your terminal, navigate to your `wordpress-develop` directory and run:
+
+**Using the Ticket Number (Recommended):**
+This will download and apply the latest patch for that ticket.
+```bash
+npm run grunt patch:27307
+```
+*(Replace `27307` with the actual ticket number)*
+
+**Using a Specific Patch URL:**
+```bash
+npm run grunt patch:https://core.trac.wordpress.org/attachment/ticket/27307/27307.diff
+```
+
+**Using a GitHub Pull Request:**
+You can apply patches directly from a GitHub Pull Request using either the direct URL or the `.diff` URL.
+
+**Option 1: Using the Direct PR URL**
+```bash
+npm run grunt patch:https://github.com/WordPress/wordpress-develop/pull/10815
+```
+
+**Option 2: Using the Diff URL**
+```bash
+npm run grunt patch:https://github.com/WordPress/wordpress-develop/pull/10815.diff
+```
+
+### 3. Build the Changes
+After applying a patch, you may need to build the changes depending on what was modified:
+
+*   **JavaScript or CSS changes:** You **MUST** run the build command to compile the assets.
+    ```bash
+    npm run build:dev
+    ```
+*   **PHP-only changes:** Running the build command is **not mandatory**, but it is good practice to ensure everything is in sync.
+
+
+## Running Tests
+
+Once a patch is applied, you should run automated tests to ensure no regressions were introduced.
+
+For detailed instructions on running PHPUnit and E2E tests, see [Run Automated Tests](https://make.wordpress.org/test/handbook/get-setup-for-testing/run-automated-tests/).
+
+
+## Troubleshooting
+
+### "Patch failed to apply"
+- **Cause:** The code in your local version might be different from what the patch expects (e.g., your branch is outdated).
+- **Fix:** Update your repository to the latest trunk before applying the patch:
+  ```bash
+  git checkout trunk
+  git pull upstream trunk
+  ```
+
+### "Cannot find module 'grunt-cli/bin/grunt'"
+- **Cause:** Missing dependencies.
+- **Fix:** Reinstall dependencies:
+  ```bash
+  rm -rf node_modules
+  npm install
+  ```
+
+### Reverting Changes
+To remove a patch and go back to a clean state:
+```bash
+git checkout .
+git clean -fd
+```

--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -9,6 +9,9 @@ Grunt is a JavaScript-based task runner that WordPress uses to automate developm
 
 ## Applying Patches
 
+**Prefer a video walkthrough?**\
+Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=5MRJ8687gF4) as you work through the instructions below.
+
 The most common task for testers is applying a patch from a Trac ticket to your local environment.
 
 ### 1. Find the Ticket or Patch ID
@@ -85,3 +88,6 @@ To remove a patch and go back to a clean state:
 git checkout .
 git clean -fd
 ```
+
+## Resources
+- [WPContrib WordPress Test Contributor Pathway YouTube Channel](https://www.youtube.com/@WPContrib) by [@SirLouen](https://profiles.wordpress.org/sirlouen/)

--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -73,6 +73,10 @@ For detailed instructions on running PHPUnit and E2E tests, see [Run Automated T
   git checkout trunk
   git pull upstream trunk
   ```
+  If you get an error about `upstream` not being found, add it first:
+  ```bash
+  git remote add upstream https://github.com/WordPress/wordpress-develop.git
+  ```
 
 ### "Cannot find module 'grunt-cli/bin/grunt'"
 - **Cause:** Missing dependencies.


### PR DESCRIPTION
Adds new handbook pages for setting up a local testing environment, using Grunt to test core tickets, and running automated tests. Updates the handbook manifest to include these new pages.

Partially https://github.com/WordPress/test-handbook/issues/7