### PR TITLE
Improve formatting in testing environment documentation

### DIFF
--- a/get-setup-for-testing/run-automated-tests.md
+++ b/get-setup-for-testing/run-automated-tests.md
@@ -41,14 +41,16 @@ npm run test:e2e
 ### "Error: ECONNREFUSED"
 - **Cause:** The local environment or Docker is not running.
 - **Fix:** Start Docker Desktop and run:
-  ```bash
-  npm run env:start
-  ```
+
+```bash
+npm run env:start
+```
 
 ### "Database connection failed"
 - **Cause:** The database container isn't ready or needs to be reset.
 - **Fix:** Wait a few seconds and try again, or reset the environment:
-  ```bash
-  npm run env:reset
-  npm run env:install
-  ```
+
+```bash
+npm run env:reset
+npm run env:install
+```

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -37,7 +37,7 @@ Before you begin, ensure you have the following installed on your computer:
 **Prefer a video walkthrough?**
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
-1.  **Fork and Clone the Repository**
+1.  **Fork and Clone the Repository** <br>
     Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
@@ -46,25 +46,25 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
     Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
-2.  **Install Dependencies**
+2.  **Install Dependencies** <br>
     Run the following command to install the necessary JavaScript and PHP tools:
     ```bash
     npm install
     ```
 
-3.  **Build WordPress**
+3.  **Build WordPress** <br>
     Compile the source files into a running WordPress instance:
     ```bash
     npm run build:dev
     ```
 
-4.  **Start the Environment**
+4.  **Start the Environment** <br>
     Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start
     ```
 
-5.  **Install WordPress**\
+5.  **Install WordPress** <br>
     Run the installation script to set up the database and site:
     ```bash
     npm run env:install

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -34,10 +34,10 @@ Before you begin, ensure you have the following installed on your computer:
 
 ### Setup Instructions
 
-**Prefer a video walkthrough?**\
+**Prefer a video walkthrough?**
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
-1.  **Fork and Clone the Repository**\
+1.  **Fork and Clone the Repository**
     Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
@@ -46,19 +46,19 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
     Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
-2.  **Install Dependencies**\
+2.  **Install Dependencies**
     Run the following command to install the necessary JavaScript and PHP tools:
     ```bash
     npm install
     ```
 
-3.  **Build WordPress**\
+3.  **Build WordPress**
     Compile the source files into a running WordPress instance:
     ```bash
     npm run build:dev
     ```
 
-4.  **Start the Environment**\
+4.  **Start the Environment**
     Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -34,7 +34,7 @@ Before you begin, ensure you have the following installed on your computer:
 
 ### Setup Instructions
 
-**Prefer a video walkthrough?**
+**Prefer a video walkthrough?** <br/>
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
 1.  **Fork and Clone the Repository** <br>

--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -9,7 +9,7 @@ Grunt is a JavaScript-based task runner that WordPress uses to automate developm
 
 ## Applying Patches
 
-**Prefer a video walkthrough?**\
+**Prefer a video walkthrough?**
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=5MRJ8687gF4) as you work through the instructions below.
 
 The most common task for testers is applying a patch from a Trac ticket to your local environment.
@@ -51,9 +51,10 @@ npm run grunt patch:https://github.com/WordPress/wordpress-develop/pull/10815.di
 After applying a patch, you may need to build the changes depending on what was modified:
 
 *   **JavaScript or CSS changes:** You **MUST** run the build command to compile the assets.
-    ```bash
-    npm run build:dev
-    ```
+
+```bash
+npm run build:dev
+```
 *   **PHP-only changes:** Running the build command is **not mandatory**, but it is good practice to ensure everything is in sync.
 
 
@@ -69,11 +70,14 @@ For detailed instructions on running PHPUnit and E2E tests, see [Run Automated T
 ### "Patch failed to apply"
 - **Cause:** The code in your local version might be different from what the patch expects (e.g., your branch is outdated).
 - **Fix:** Update your repository to the latest trunk before applying the patch:
-  ```bash
-  git checkout trunk
-  git pull upstream trunk
-  ```
+
+```bash
+git checkout trunk
+git pull upstream trunk
+```
+
   If you get an error about `upstream` not being found, add it first:
+  
   ```bash
   git remote add upstream https://github.com/WordPress/wordpress-develop.git
   ```
@@ -81,10 +85,11 @@ For detailed instructions on running PHPUnit and E2E tests, see [Run Automated T
 ### "Cannot find module 'grunt-cli/bin/grunt'"
 - **Cause:** Missing dependencies.
 - **Fix:** Reinstall dependencies:
-  ```bash
-  rm -rf node_modules
-  npm install
-  ```
+
+```bash
+rm -rf node_modules
+npm install
+```
 
 ### Reverting Changes
 To remove a patch and go back to a clean state:


### PR DESCRIPTION
After #110 was merged, I noticed some markdown formatting issues in the new testing environment documentation.

This PR fixes:
- Trailing backslashes (\) after header lines that were causing rendering issues
- Inconsistent code block indentation throughout the affected files