### PR TITLE
Update Get Setup for Testing Landing Page

### DIFF
--- a/get-setup-for-testing/index.md
+++ b/get-setup-for-testing/index.md
@@ -1,6 +1,10 @@
 # Get Set Up for Testing
 
-Welcome to the WordPress Test Team! Contributing to testing is one of the most impactful ways to help make WordPress better for everyone. Whether you have 10 minutes or several hours, there is a testing task suited to your setup and skill level.
+Getting involved with WordPress testing is a great way to contribute and also a chance to learn.
+
+Trying to reproduce bugs and testing patches exposes you to real bugs, edge cases, and development decisions that sharpen your skills and deepen your understanding of how WordPress is built.
+
+And regardless of your experience level or how much time you have, there is always a ticket to pick up.
 
 ## What Would You Like to Test?
 

--- a/get-setup-for-testing/index.md
+++ b/get-setup-for-testing/index.md
@@ -87,7 +87,7 @@ Recent examples include:
 
 ## Get Involved
 
-- **Join the conversation:** Testing discussions happen in the [#test](https://make.wordpress.org/chat/) channel on the WordPress Slack.
+- **Join the conversation:** Testing discussions happen in the [#core-test](https://wordpress.slack.com/messages/core-test/) channel on the WordPress Slack.
 - **Weekly meetings:** Check the [Make/Test calendar](https://make.wordpress.org/meetings/#test) for meeting times.
 - **Stay updated:** Follow the [Make WordPress Test blog](https://make.wordpress.org/test/) for announcements and testing posts.
 

--- a/get-setup-for-testing/index.md
+++ b/get-setup-for-testing/index.md
@@ -21,7 +21,7 @@ Before testing core tickets, you need an environment where you can apply patches
 | Option | Best For |
 |---|---|
 | **WordPress Playground** (browser-based) | Quick visual verification of a PR; no local install needed |
-| **Local development environment** (Docker-based) | Running automated tests, applying `.patch` files, complex testing |
+| **Local development environment** (Docker-based) | Running automated tests, applying `.patch` and `.diff` files, complex testing |
 
 👉 **[Set Up a Testing Environment](https://make.wordpress.org/test/handbook/get-setup-for-testing/set-up-a-testing-environment/)**
 
@@ -29,8 +29,8 @@ Before testing core tickets, you need an environment where you can apply patches
 
 Once your environment is ready, pick a ticket to test:
 
-- **[Test Core Tickets with Playground](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-playground/)** – Use this for tickets linked to a GitHub Pull Request (PR). No local setup required. *(Note: `.patch` files from Trac are not supported in Playground.)*
-- **[Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/)** – Use this to apply `.patch` files from Trac, or patches from GitHub Pull Requests, to your local environment.
+- **[Test Core Tickets with Playground](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-playground/)** – Use this for tickets linked to a GitHub Pull Request (PR). No local setup required. *(Note: `.patch` and `.diff` files from Trac are not supported in Playground.)*
+- **[Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/)** – Use this to apply `.patch` and `.diff` files from Trac, or patches from GitHub Pull Requests, to your local environment.
 
 ### Step 3 – Run Automated Tests
 

--- a/get-setup-for-testing/index.md
+++ b/get-setup-for-testing/index.md
@@ -1,43 +1,94 @@
 # Get Set Up for Testing
 
-Welcome! To help test, your first step will be to set up a test environment.
+Welcome to the WordPress Test Team! Contributing to testing is one of the most impactful ways to help make WordPress better for everyone. Whether you have 10 minutes or several hours, there is a testing task suited to your setup and skill level.
 
-## Set Up a Hosted WordPress Site
+## What Would You Like to Test?
 
-1. If you already have hosting setup for a site you own, consider asking your web host how to add an additional site in a subdomain or subfolder for testing purposes. Each host may have different options, and they should be able to help advise you.  
-2. If you have a small budget to work with, setting up additional hosting to use for testing is helpful because it also helps to diversify tests in varying different environments.  
-3. You can go to [https://wordpress.org/hosting/](https://wordpress.org/hosting/) to see a list of recommended hosts.
+Testing in the WordPress project covers several areas. Choose the section that matches your interests:
 
-## Install in a Local Environment
+- **[WordPress Core](#test-wordpress-core)** – Patches, tickets, and automated test suites for WordPress core.
+- **[Gutenberg / Block Editor](#test-gutenberg)** – Features and releases from the Gutenberg plugin.
+- **[Calls for Testing](#calls-for-testing)** – Curated, focused testing tasks published by the Test Team.
 
-Use this option if you would like to test pull requests or if you would like to check if something is working with the bleeding edge version.
+## Test WordPress Core
 
-1. Make sure you have [git](https://git-scm.com), [node](https://nodejs.org), and [npm](https://www.npmjs.com/get-npm) installed.  
-2. Install [docker](https://www.docker.com).  
-3. [Clone](https://help.github.com/articles/cloning-a-repository/) the [gutenberg](https://github.com/WordPress/gutenberg) repository locally.  
-4. Run `npm install`.  
-5. Run `npm run wp-env start`.  
-6. Open [http://localhost:8888](http://localhost:8888) in your browser (username: `admin`, password: `password`).
+WordPress core development happens in the [`wordpress-develop`](https://github.com/WordPress/wordpress-develop) repository. Core tickets live on [Trac](https://core.trac.wordpress.org/). The guides below will walk you through setting up and contributing to core testing.
 
-Need more detailed installation instructions? Please see [Contributing](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) in the documentation.
+### Step 1 – Set Up a Testing Environment
 
-## Install Gutenberg as a Plugin
+Before testing core tickets, you need an environment where you can apply patches. There are two approaches:
 
-Use this option to do general testing with the latest beta or release candidate versions of the Gutenberg editor:
+| Option | Best For |
+|---|---|
+| **WordPress Playground** (browser-based) | Quick visual verification of a PR; no local install needed |
+| **Local development environment** (Docker-based) | Running automated tests, applying `.patch` files, complex testing |
 
-1. Go to [https://github.com/WordPress/gutenberg/releases](https://github.com/WordPress/gutenberg/releases). Note: you may need to scroll through several pages of dependencies.  
-2. Download the latest `gutenberg.zip` file.  
-3. Go to WP Admin > Plugins > Add New > Upload Plugin.  
-4. Select the file from step 2.  
-5. Follow the prompts to install and activate the plugin.
+👉 **[Set Up a Testing Environment](https://make.wordpress.org/test/handbook/get-setup-for-testing/set-up-a-testing-environment/)**
 
-## Useful Commands
+### Step 2 – Apply and Test a Patch
 
-*All of these commands are intended to be run from Terminal, in your Gutenberg directory.*
+Once your environment is ready, pick a ticket to test:
 
-- Running `npm install` occasionally is a useful habit, as well as any time you know that `package.json` has been changed.  
-- If you restart your computer, or upgrade Docker, start the Gutenberg containers again by running: `docker-compose up -d`
-- It’s a good practice to stop (with `Ctrl+C`) `npm run dev` and restart when you switch to a different branch.  
-- If everything is broken, and you have no idea what’s happened, run `bin/setup-local-env.sh` again to reset everything to a fresh install.
+- **[Test Core Tickets with Playground](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-playground/)** – Use this for tickets linked to a GitHub Pull Request (PR). No local setup required. *(Note: `.patch` files from Trac are not supported in Playground.)*
+- **[Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/)** – Use this to apply `.patch` files from Trac, or patches from GitHub Pull Requests, to your local environment.
 
-Thank you for testing!
+### Step 3 – Run Automated Tests
+
+After applying a patch, running the automated test suites helps catch regressions before code is merged. Ensure you have completed Steps 1 and 2 above — automated tests require a local environment with a patch already applied.
+
+👉 **[Run Automated Tests](https://make.wordpress.org/test/handbook/get-setup-for-testing/run-automated-tests/)**
+
+### Finding Tickets to Test
+
+A great place to start is the [Needs Patch Testing](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=new&status=reopened&status=reviewing&keywords=~needs-testing+has-patch&focuses=!docs&col=id&col=summary&col=focuses&col=keywords&col=owner&col=type&col=priority&col=changetime&desc=1&order=changetime) queue on Core Trac. These are tickets with patches that need a fresh set of eyes.
+
+## Test Gutenberg
+
+The Gutenberg plugin ships block editor features before they land in WordPress core. You can test pre-release versions of Gutenberg in a few ways:
+
+### Install Gutenberg as a Plugin
+
+Use this option to test the latest beta or release candidate of Gutenberg on an existing site:
+
+1. Go to [https://github.com/WordPress/gutenberg/releases](https://github.com/WordPress/gutenberg/releases).
+2. Download the latest `gutenberg.zip` file.
+3. Go to **WP Admin → Plugins → Add New → Upload Plugin**.
+4. Select the file and follow the prompts to install and activate.
+
+### Run Gutenberg Locally
+
+Use this option if you want to test pull requests or work with the bleeding-edge development version:
+
+1. Make sure you have [git](https://git-scm.com), [Node.js](https://nodejs.org) (v20+), and [npm](https://www.npmjs.com/get-npm) (v10+) installed.
+2. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+3. Fork and [clone](https://help.github.com/articles/cloning-a-repository/) the [gutenberg](https://github.com/WordPress/gutenberg) repository locally.
+4. Run `npm install` to install dependencies.
+5. Run `npm run dev` to build Gutenberg in development mode (continuous rebuild on file changes).
+6. Make sure Docker is running, then start the local WordPress environment: `npm run wp-env start`.
+7. Open [http://localhost:8888](http://localhost:8888) in your browser (username: `admin`, password: `password`).
+
+The Gutenberg plugin will be installed and activated automatically in the local environment.
+
+**Resources:**
+- [Getting Started with Code Contribution](https://developer.wordpress.org/block-editor/contributors/code/getting-started-with-code-contribution/) – Block Editor Handbook
+- [Testing Overview](https://developer.wordpress.org/block-editor/contributors/code/testing-overview/) – Block Editor Handbook
+
+## Calls for Testing
+
+The WordPress Test Team regularly publishes **Calls for Testing** — focused tasks that guide testers through specific features or bug fixes. These posts include step-by-step instructions and are a great starting point for new contributors.
+
+👉 **[View all Calls for Testing](https://make.wordpress.org/test/category/call-for-testing/)**
+
+Recent examples include:
+
+- [It's time to test real-time collaboration!](https://make.wordpress.org/test/2026/03/11/its-time-to-test-real-time-collaboration/) *(March 2026)*
+- [Call for Testing – Pattern editing and content-only interactivity in WordPress 7.0](https://make.wordpress.org/test/2026/02/27/call-for-testing-pattern-editing-and-content-only-interactivity-in-wordpress-7-0/) *(February 2026)*
+- [Help Test WordPress 7.0](https://make.wordpress.org/test/2026/02/20/help-test-wordpress-7-0/) *(February 2026)*
+
+## Get Involved
+
+- **Join the conversation:** Testing discussions happen in the [#test](https://make.wordpress.org/chat/) channel on the WordPress Slack.
+- **Weekly meetings:** Check the [Make/Test calendar](https://make.wordpress.org/meetings/#test) for meeting times.
+- **Stay updated:** Follow the [Make WordPress Test blog](https://make.wordpress.org/test/) for announcements and testing posts.
+
+Thank you for helping test WordPress! 🎉


### PR DESCRIPTION
This PR updates the [Get Setup for Testing landing page](https://make.wordpress.org/test/handbook/get-setup-for-testing/) to align with our latest testing guides.
Specifically, it:
- Removes the outdated "Set Up a Hosted Site" and "Useful Local Commands" sections, as they are no longer necessary with our new, streamlined guides.
- Modernizes the content to match current workflows.

See:
https://github.com/WordPress/test-handbook/pull/110#issuecomment-4142237429 
https://github.com/WordPress/test-handbook/pull/110#issuecomment-4147354441
https://github.com/WordPress/test-handbook/pull/110#issuecomment-4147488980
https://github.com/WordPress/test-handbook/issues/111#issuecomment-4147491922
