### PR TITLE
Fix remaining indentation issue in Grunt testing documentation

### DIFF
--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -76,11 +76,11 @@ git checkout trunk
 git pull upstream trunk
 ```
 
-  If you get an error about `upstream` not being found, add it first:
-  
-  ```bash
-  git remote add upstream https://github.com/WordPress/wordpress-develop.git
-  ```
+If you get an error about `upstream` not being found, add it first:
+
+```bash
+git remote add upstream https://github.com/WordPress/wordpress-develop.git
+```
 
 ### "Cannot find module 'grunt-cli/bin/grunt'"
 - **Cause:** Missing dependencies.


### PR DESCRIPTION
This PR includes a minor formatting fix to correct the indentation for the `upstream` instructions block.

In a previous PR where we addressed backslash handling and code block indentation, this specific case was missed. This update ensures consistency and proper formatting across the documentation.

Ref: https://github.com/WordPress/test-handbook/pull/124
