### PR TITLE
Correcting multiple grammatical issues in call-for-testing.md

### DIFF
--- a/call-for-testing.md
+++ b/call-for-testing.md
@@ -75,7 +75,7 @@ If you’re struggling to get feedback, please view these [high level suggestion
 
 No matter what approach you’re using, the key is to ensure that information gets back to the right place. Usually, this means issues in [Trac](https://trac.wordpress.org/) or issues in the [Gutenberg GitHub repo](https://github.com/WordPress/gutenberg/issues).
 
-### Self serve calls for testing approach
+### Self-serve calls for testing approach
 
 This is a mostly hands off approach and solely requires clarity upfront in the call for testing you write. Any extra time you can spend ensuring that the instructions for where and how to report issues/feedback will be very high impact. This might include a short video around how to report or linking off to resources, like [how to use Trac on Learn WordPress](https://learn.wordpress.org/tutorial/how-to-use-trac/).
 

--- a/call-for-testing.md
+++ b/call-for-testing.md
@@ -79,7 +79,7 @@ No matter what approach you’re using, the key is to ensure that information ge
 
 This is a mostly hands off approach and solely requires clarity up front in the call for testing you write. Any extra time that you can spend ensuring that the instructions for where and how to report issues/feedback will be very high impact. This might include a short video around how to report or linking off to resources, like [how to use Trac on Learn WordPress](https://learn.wordpress.org/tutorial/how-to-use-trac/).
 
-The biggest downside to this approach is that it requires a greater time investment of those reporting issues to both simply do the work to open an issue/comment on a current one and to know how to. This usually results in less engagement.
+The biggest downside to this approach is that it requires a greater time investment of those reporting issues to both simply do the work to open an issue/comment on a current one and to know how to do so. This usually results in less engagement.
 
 ### Facilitated calls for testing approach
 

--- a/call-for-testing.md
+++ b/call-for-testing.md
@@ -77,7 +77,7 @@ No matter what approach you’re using, the key is to ensure that information ge
 
 ### Self-serve calls for testing approach
 
-This is a mostly hands off approach and solely requires clarity upfront in the call for testing you write. Any extra time you can spend ensuring that the instructions for where and how to report issues/feedback will be very high impact. This might include a short video around how to report or linking off to resources, like [how to use Trac on Learn WordPress](https://learn.wordpress.org/tutorial/how-to-use-trac/).
+This is a mostly hands off approach and solely requires clarity up front in the call for testing you write. Any extra time you can spend ensuring that the instructions for where and how to report issues/feedback will be very high impact. This might include a short video around how to report or linking off to resources, like [how to use Trac on Learn WordPress](https://learn.wordpress.org/tutorial/how-to-use-trac/).
 
 The biggest downside to this approach is that it requires a greater time investment of those reporting issues to both simply do the work to open an issue/comment on a current one and to know how to. This usually results in less engagement.
 

--- a/call-for-testing.md
+++ b/call-for-testing.md
@@ -77,7 +77,7 @@ No matter what approach you’re using, the key is to ensure that information ge
 
 ### Self-serve calls for testing approach
 
-This is a mostly hands off approach and solely requires clarity up front in the call for testing you write. Any extra time you can spend ensuring that the instructions for where and how to report issues/feedback will be very high impact. This might include a short video around how to report or linking off to resources, like [how to use Trac on Learn WordPress](https://learn.wordpress.org/tutorial/how-to-use-trac/).
+This is a mostly hands off approach and solely requires clarity up front in the call for testing you write. Any extra time that you can spend ensuring that the instructions for where and how to report issues/feedback will be very high impact. This might include a short video around how to report or linking off to resources, like [how to use Trac on Learn WordPress](https://learn.wordpress.org/tutorial/how-to-use-trac/).
 
 The biggest downside to this approach is that it requires a greater time investment of those reporting issues to both simply do the work to open an issue/comment on a current one and to know how to. This usually results in less engagement.
 


### PR DESCRIPTION
Correcting multiple grammatical issues in call-for-testing.md

- Add hyphen to "self-serve" ["Self serve" as a compound modifier before "calls for testing approach"
requires a hyphen for clarity and correctness.]
- Change "upfront" to "up front" [When used adverbially to mean "in advance," "up front" should be two words.]
- Add missing "that" after "Any extra time" [Insert "that" to improve sentence clarity and grammatical flow in the
clause beginning "Any extra time you can spend..."]
- Complete dangling "how to" with "do so" [The phrase "and to know how to" was left incomplete. Add "do so" to
clarify the intended meaning (how to open an issue/comment).]

