### PR TITLE
Fix grammar, punctuation, and clarity issues in `test-handbook/team-reps/index.md` file

### DIFF
--- a/team-reps/index.md
+++ b/team-reps/index.md
@@ -36,7 +36,7 @@ Test Team Reps must be committed to showing up and performing regular duties, an
 
 The first step is to reach out to the community with a Call for Nominations, such as these examples from [2024](https://make.wordpress.org/test/2024/08/13/test-team-reps-call-for-nominations-4/) and [2025](https://make.wordpress.org/test/2025/08/14/test-team-reps-call-for-nominations-5/). Nominations are held each August, with the new term starting by September.
 
-Self-nominations are the primary way of getting into the elections list “I nominate for the Test Team Reps position.” Also other Team Members could nominate someone else “I nominate @username for the Test Team Reps position.” but the nominee must accept the nomination before the nomination period ends to be valid. Just answering to the Call for Nominations post is sufficient to nominate oneself or someone else.
+Self-nominations are the primary way of getting into the elections list with a statement such as "I nominate myself for the Test Team Reps position." Also other Team Members could nominate someone else “I nominate @username for the Test Team Reps position.” but the nominee must accept the nomination before the nomination period ends to be valid. Just answering to the Call for Nominations post is sufficient to nominate oneself or someone else.
 
 ### Step 2: Criteria of Eligibility
 

--- a/team-reps/index.md
+++ b/team-reps/index.md
@@ -36,7 +36,9 @@ Test Team Reps must be committed to showing up and performing regular duties, an
 
 The first step is to reach out to the community with a Call for Nominations, such as these examples from [2024](https://make.wordpress.org/test/2024/08/13/test-team-reps-call-for-nominations-4/) and [2025](https://make.wordpress.org/test/2025/08/14/test-team-reps-call-for-nominations-5/). Nominations are held each August, with the new term starting by September.
 
-Self-nominations are the primary way of getting into the elections list with a statement such as "I nominate myself for the Test Team Reps position." Also other Team Members could nominate someone else — for example, "I nominate @username for the Test Team Reps position" — but the nominee must accept the nomination before the nomination period ends to be valid. Just replying to the Call for Nominations post is sufficient to nominate oneself or someone else.
+Self-nominations are the primary way to get on the elections list. To nominate yourself, simply state: "I nominate myself for the Test Team Reps position."
+Other Team Members may also nominate someone else, for example: "I nominate @username for the Test Team Reps position." However, the nominee must accept the nomination before the nomination period ends for it to be valid.
+In both cases, replying to the Call for Nominations post is sufficient to submit a nomination.
 
 ### Step 2: Criteria of Eligibility
 

--- a/team-reps/index.md
+++ b/team-reps/index.md
@@ -36,7 +36,7 @@ Test Team Reps must be committed to showing up and performing regular duties, an
 
 The first step is to reach out to the community with a Call for Nominations, such as these examples from [2024](https://make.wordpress.org/test/2024/08/13/test-team-reps-call-for-nominations-4/) and [2025](https://make.wordpress.org/test/2025/08/14/test-team-reps-call-for-nominations-5/). Nominations are held each August, with the new term starting by September.
 
-Self-nominations are the primary way of getting into the elections list with a statement such as "I nominate myself for the Test Team Reps position." Also other Team Members could nominate someone else “I nominate @username for the Test Team Reps position.” but the nominee must accept the nomination before the nomination period ends to be valid. Just answering to the Call for Nominations post is sufficient to nominate oneself or someone else.
+Self-nominations are the primary way of getting into the elections list with a statement such as "I nominate myself for the Test Team Reps position." Also other Team Members could nominate someone else “I nominate @username for the Test Team Reps position.” but the nominee must accept the nomination before the nomination period ends to be valid. Just replying to the Call for Nominations post is sufficient to nominate oneself or someone else.
 
 ### Step 2: Criteria of Eligibility
 

--- a/team-reps/index.md
+++ b/team-reps/index.md
@@ -36,7 +36,7 @@ Test Team Reps must be committed to showing up and performing regular duties, an
 
 The first step is to reach out to the community with a Call for Nominations, such as these examples from [2024](https://make.wordpress.org/test/2024/08/13/test-team-reps-call-for-nominations-4/) and [2025](https://make.wordpress.org/test/2025/08/14/test-team-reps-call-for-nominations-5/). Nominations are held each August, with the new term starting by September.
 
-Self-nominations are the primary way of getting into the elections list with a statement such as "I nominate myself for the Test Team Reps position." Also other Team Members could nominate someone else “I nominate @username for the Test Team Reps position.” but the nominee must accept the nomination before the nomination period ends to be valid. Just replying to the Call for Nominations post is sufficient to nominate oneself or someone else.
+Self-nominations are the primary way of getting into the elections list with a statement such as "I nominate myself for the Test Team Reps position." Also other Team Members could nominate someone else — for example, "I nominate @username for the Test Team Reps position" — but the nominee must accept the nomination before the nomination period ends to be valid. Just replying to the Call for Nominations post is sufficient to nominate oneself or someone else.
 
 ### Step 2: Criteria of Eligibility
 


### PR DESCRIPTION
## Summary
This PR fixes multiple grammatical and clarity issues in `test-handbook/team-reps/index.md` file.

## Changes

### 1. Fix(grammar): restructure self-nomination sentence for clarity
**Issue:** The sentence runs into the quoted example without proper separation. The quote appears to be an example of what someone would say, but the transition is abrupt.
### 2. Fix(grammar): change `answering to` to `replying to` for clarity
**Issue:** The correct preposition is "answering" without "to" when referring to responding to a post. "Answering to" means being subordinate to or accountable to someone.
### 3. Fix(punctuation): improve punctuation and flow around quotation
**Issue:** The period inside the quote followed immediately by "but" creates an awkward break. Also missing space or transition.

## Type of change
- [x] Fixing grammar/punctuation
- [x] Documentation improvement