### PR TITLE
chore: add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+Thumbs.db
 .claude/settings.local.json


### PR DESCRIPTION
- Add `.claude/settings.local.json` to `.gitignore`

This prevents local Claude Code configuration (including API tokens and custom endpoints) from being accidentally committed to the repository.