### PR TITLE
Add Team Organization page with active and emeritus member sections

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -20,6 +20,13 @@
         "parent": "team-reps",
         "order": 1
     },
+    "team-organization": {
+        "title": "Team Organization",
+        "slug": "team-organization",
+        "markdown_source": "https:\/\/github.com\/WordPress\/test-handbook\/blob\/trunk\/team-organization.md",
+        "parent": null,
+        "order": 15
+    },
     "get-setup-for-testing": {
         "title": "Get Setup for Testing",
         "slug": "get-setup-for-testing",

--- a/team-organization.md
+++ b/team-organization.md
@@ -1,0 +1,73 @@
+# Team Organization
+
+The WordPress Test Team is a group of contributors dedicated to improving the quality of WordPress through manual and automated testing, triage, and education. This page provides an overview of how the team is organized, who its active members are, and how new contributors can get involved.
+
+For more about the team's mission and scope, see the [Test Team Handbook Homepage](https://make.wordpress.org/test/handbook/).
+
+## Roles
+
+### Team Reps
+
+Team Reps are elected annually and serve as the primary coordinators of the Test Team. They facilitate meetings, publish updates, and represent the team across the WordPress project. For full details on the role and election process, see the [Team Reps](https://make.wordpress.org/test/handbook/team-reps/) page.
+
+**Current Reps (2025-2026):**
+
+| Name | Username |
+| --- | --- |
+| Nikunj Hatkar | [@nikunj8866](https://profiles.wordpress.org/nikunj8866/) |
+| Moses Cursor Ssebunya| [@mosescursor](https://profiles.wordpress.org/mosescursor/) |
+
+### Contributors
+
+Test Team Contributors are active members who regularly participate in one or more of the team's activities, such as:
+
+- Leading or attending [Test Team chats](https://make.wordpress.org/meetings/#test) and [Patch Testing Scrubs](https://wordpress.slack.com/archives/C03B0H5J0)
+- Writing [test reports](https://make.wordpress.org/test/handbook/test-reports/) (issue reproduction, patch testing, or combined reports)
+- [Triaging](https://make.wordpress.org/test/handbook/triage/) tickets on [Trac](https://core.trac.wordpress.org/) or [GitHub](https://github.com/WordPress/gutenberg/issues)
+- Contributing to [Test Handbook documentation](https://github.com/WordPress/test-handbook/)
+
+## Active Members
+
+The following contributors are currently active in the Test Team. This list is updated periodically to reflect ongoing participation.
+
+<!-- Placeholder: Add active members here. Example format:
+| Name | Username | Focus Area(s) |
+| --- | --- | --- |
+| First Last | [@username](https://profiles.wordpress.org/username/) | Triage, Patch Testing |
+| First Last | [@username](https://profiles.wordpress.org/username/) | Meeting Facilitation, Documentation |
+-->
+
+
+## Emeritus Members
+
+Emeritus status recognizes contributors who have made sustained, significant contributions to the Test Team over an extended period. This is a permanent acknowledgment of their dedication to the team and the WordPress project.
+
+<!-- Placeholder: Add emeritus members here. Example format:
+| Name | Username | Contributions |
+| --- | --- | --- |
+| First Last | [@username](https://profiles.wordpress.org/username/) | Team Rep (2022-2023), Triage Lead |
+-->
+
+## How to Join
+
+The Test Team welcomes contributors of all skill levels. There are several paths to getting involved:
+
+### 1. Start Contributing
+
+The simplest way to join is to start contributing. Pick an area that interests you and dive in:
+
+- **Testing**: Follow the [Get Setup for Testing](https://make.wordpress.org/test/handbook/get-setup-for-testing/) guide, then try [reproducing an issue](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/) or [testing a patch](https://make.wordpress.org/test/handbook/test-reports/patch-testing/).
+- **Triage**: Help sort and prioritize [tickets that need attention](https://make.wordpress.org/test/handbook/triage/).
+- **Documentation**: Open a PR for [an issue in the Test Handbook repo](https://github.com/WordPress/test-handbook/issues).
+
+### 2. Attend Team Meetings
+
+Join the conversation on the [Make WordPress Slack #core-test channel](https://wordpress.slack.com/messages/core-test/). The team holds alternating weekly [Test Chats and Patch Testing Scrubs](https://make.wordpress.org/meetings/#test) where you can meet other contributors and find testing opportunities.
+
+## Activity Expectations
+
+Being an active member of the Test Team means contributing regularly and consistently. While there is no strict minimum, the team values sustained participation over occasional bursts of activity.
+
+Members who are no longer able to maintain regular contributions are encouraged to step back gracefully. Long-term contributors who have demonstrated sustained commitment may be granted [emeritus status](#emeritus-members) in recognition of their service.
+
+For details on what qualifies as "active" participation (particularly for Team Rep eligibility), see the [Team Reps Qualifications](https://make.wordpress.org/test/handbook/team-reps/#qualifications) section.

--- a/team-organization.md
+++ b/team-organization.md
@@ -30,23 +30,29 @@ Test Team Contributors are active members who regularly participate in one or mo
 
 The following contributors are currently active in the Test Team. This list is updated periodically to reflect ongoing participation.
 
-<!-- Placeholder: Add active members here. Example format:
 | Name | Username | Focus Area(s) |
 | --- | --- | --- |
-| First Last | [@username](https://profiles.wordpress.org/username/) | Triage, Patch Testing |
-| First Last | [@username](https://profiles.wordpress.org/username/) | Meeting Facilitation, Documentation |
--->
+| Huzaifa Al Mesbah | [@huzaifaalmesbah](https://profiles.wordpress.org/huzaifaalmesbah/) | Handbook Maintenance, Patch Testing, Triage |
+| Ozgur Sar | [@ozgursar](https://profiles.wordpress.org/ozgursar/) | Handbook Maintenance, Patch Testing, Triage |
+| JuanMa Garrido | [@juanmaguitar](https://profiles.wordpress.org/juanmaguitar/) | Handbook Maintenance, Triage |
+| r1k0 | [@r1k0](https://profiles.wordpress.org/r1k0/) | Handbook Maintenance, Patch Testing, Triage |
+| Shazzad Hossain Khan | [@sajib1223](https://profiles.wordpress.org/sajib1223/) | Patch Testing, Triage |
 
 
 ## Emeritus Members
 
 Emeritus status recognizes contributors who have made sustained, significant contributions to the Test Team over an extended period. This is a permanent acknowledgment of their dedication to the team and the WordPress project.
 
-<!-- Placeholder: Add emeritus members here. Example format:
 | Name | Username | Contributions |
 | --- | --- | --- |
-| First Last | [@username](https://profiles.wordpress.org/username/) | Team Rep (2022-2023), Triage Lead |
--->
+| Manuel Camargo | [@SirLouen](https://profiles.wordpress.org/sirlouen/) | Test Team Training Program, Pathway Videos |
+| Olga Gleckler | [@oglekler](https://profiles.wordpress.org/oglekler/) | Team Rep 2024-2025 |
+| Krupa Nanda | [@krupajnanda](https://profiles.wordpress.org/krupajnanda/) | Team Rep 2024-2025 |
+| Ankit K Gupta | [@ankit-k-gupta](https://profiles.wordpress.org/ankit-k-gupta/) | Team Rep 2023-2024 |
+| Pooja Derashri | [@webtechpooja](https://profiles.wordpress.org/webtechpooja/) | Team Rep 2023-2024 |
+| Piotrek Boniu | [@boniu91](https://profiles.wordpress.org/boniu91/) | Team Rep 2022-2023 |
+| Brian Alexander | [@ironprogrammer](https://profiles.wordpress.org/ironprogrammer/) | Team Rep 2021-2022, 2022-2023 |
+| Tonya Mork | [@hellofromtonya](https://profiles.wordpress.org/hellofromtonya/) | Team Rep 2022-2023 |
 
 ## How to Join
 


### PR DESCRIPTION
## Summary 
  - Adds a new Team Organization page outlining how the Test Team is structured
  - Includes sections for Team Reps, Contributors, Active Members, and Emeritus Members             
  - Adds guidance on how to join and activity expectations                             
  - Registers the new page in the handbook manifest                                                 
                                                                                                    
Closes https://github.com/WordPress/test-handbook/issues/107                                      
                                                                                                                
         