### PR TITLE
Add cross-links between setup guides and patch testing report page

### DIFF
--- a/get-setup-for-testing/test-core-tickets-with-grunt.md
+++ b/get-setup-for-testing/test-core-tickets-with-grunt.md
@@ -65,6 +65,10 @@ Once a patch is applied, you should run automated tests to ensure no regressions
 For detailed instructions on running PHPUnit and E2E tests, see [Run Automated Tests](https://make.wordpress.org/test/handbook/get-setup-for-testing/run-automated-tests/).
 
 
+## Writing a Test Report
+
+After testing a patch, share your results by writing a test report on the Trac ticket. For report templates and guidelines, see [Patch Testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/).
+
 ## Troubleshooting
 
 ### "Patch failed to apply"

--- a/get-setup-for-testing/test-core-tickets-with-playground.md
+++ b/get-setup-for-testing/test-core-tickets-with-playground.md
@@ -35,6 +35,10 @@ There are some limitations to this Playground environment. You can read more [he
 
 In the WordPress Playground environment you can test the PR for the feature changes, bug fixes, regression issues and more.
 
+## Writing a Test Report
+
+After testing a PR, share your results by writing a test report on the Trac ticket. For report templates and guidelines, see [Patch Testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/).
+
 ## How to Configure Playground Using Query API Parameters
 
 If you prefer a video walkthrough, you may follow along with this [video guide](https://www.youtube.com/watch?v=9q6unIg_Pto) as you work through the instructions below.

--- a/test-reports/patch-testing.md
+++ b/test-reports/patch-testing.md
@@ -1,6 +1,8 @@
 # Patch Testing
 Once a patch is made available for a ticket, it is critical to validate that the code change (a) addresses the issue (for bug report) or (b) delivers the expected behavior or result (for feature or enhancement).
 
+If you haven't applied a patch yet, see [Test Core Tickets with Playground](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-playground/) or [Test Core Tickets with Grunt](https://make.wordpress.org/test/handbook/get-setup-for-testing/test-core-tickets-with-grunt/) to get started.
+
 During patch testing, please be aware of “regression” issues, where the patch may fix one thing, but break another unintentionally.
 
 Example patch testing reports:


### PR DESCRIPTION
## Summary
- Adds a "Writing a Test Report" section in `test-core-tickets-with-grunt.md` and `test-core-tickets-with-playground.md` linking to `test-reports/patch-testing`
- Adds a note in `test-reports/patch-testing.md` linking back to the Playground and Grunt setup pages

Fixes #150

## Test plan
- [ ] Verify the new links in `test-core-tickets-with-grunt.md` point correctly to the Patch Testing page
- [ ] Verify the new links in `test-core-tickets-with-playground.md` point correctly to the Patch Testing page
- [ ] Verify the new links in `test-reports/patch-testing.md` point correctly to the Playground and Grunt setup pages