### PR TITLE
Bump actions/cache to v4.3.0 to fix deprecation failure

### DIFF
--- a/.github/workflows/weekly-testing-digest.yml
+++ b/.github/workflows/weekly-testing-digest.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Cache Playwright browsers
               id: playwright-cache
-              uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-chromium-${{ runner.os }}-${{ hashFiles('.github/scripts/package.json') }}


### PR DESCRIPTION
## Summary

The Weekly Testing Digest workflow added in #155 currently fails before any code runs. GitHub deprecated the cache service used by `actions/cache` versions earlier than `v4.2.0`, and the workflow pins `v4.1.2`:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 6849a6489940f00c2f30c0fb92c6274307ccb58a`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions.

Reference: [GitHub changelog – Dec 5, 2024](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)

This bumps the pin to `v4.3.0` (`0057852bfaa89a56745cba8c7296529d2fc39830`), the latest `v4` release at the time of writing.

## Validation

Dispatched against this branch on my fork in dry-run mode (no Slack secret on the fork — script logs the payload instead of posting):

- Run: https://github.com/juanma-wp/test-handbook/actions/runs/25722279037
- Result: ✅ success — cache step runs, npm install + Playwright install + Trac scrape + GitHub Search API all complete

The Node.js 20 deprecation warning that appears for `actions/cache`, `actions/checkout`, and `actions/setup-node` is informational only (cutoff: June 2, 2026). Out of scope for this PR.

## Test plan

- [ ] Merge
- [ ] Trigger `Weekly Testing Digest` via `workflow_dispatch` on trunk to confirm CI no longer fails on action setup
- [ ] Confirm the next scheduled Monday 09:00 UTC run completes and posts to `#core-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)