### PR TITLE
Fix the GitHub issues  payload link

### DIFF
--- a/.github/scripts/weekly-testing-digest.mjs
+++ b/.github/scripts/weekly-testing-digest.mjs
@@ -58,7 +58,7 @@ async function fetchGitHubCount( type ) {
  */
 function buildGitHubURL( type ) {
 	const encodedLabel = encodeURIComponent( `"${ LABEL }"` );
-	const typeQualifier = type === 'pulls' ? '+is%3Apr' : '';
+	const typeQualifier = type === 'pulls' ? '+is%3Apr' : '+is%3Aissue';
 	return `https://github.com/${ REPO }/${ type }?q=is%3Aopen${ typeQualifier }+label%3A${ encodedLabel }`;
 }
 


### PR DESCRIPTION
Currently, the [link](https://github.com/WordPress/gutenberg/pulls?q=is%3Aopen+is%3Apr+label%3A%22Needs%20Testing%22) to the issues is leading to the general needs testing (Issues + PR). So, when using the link in the payload, you might think there is a count difference. 

This PR fixes this by including the `is%3Aissue` to the link parameters.