### PR TITLE
Add Patch Testing Scrub Guide links

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ Test Team contributions touch on all aspects of manual and automated testing wit
 - [Patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/)
 - Feature and enhancement testing
 - End-to-end (E2E) testing
-- Patch testing scrubbing
+- [Patch testing scrubbing](https://make.wordpress.org/test/handbook/team-reps/patch-testing-scrub-guide/)
 - Education, outreach, and documentation
 
 With such a wide range of opportunities available, contributors are sure to find an area of interest to help make WordPress better.

--- a/team-reps/index.md
+++ b/team-reps/index.md
@@ -17,7 +17,7 @@ Test Team Rep duties include:
 - Write weekly [Test Team Update](https://make.wordpress.org/updates/tag/test/) posts, and post to [Team Updates](https://make.wordpress.org/updates/).
 - Write weekly [Week in Test](https://make.wordpress.org/test/category/week-in-test/) posts, and post to [Make WordPress Test](https://make.wordpress.org/test/).
 - Write agenda for bi-weekly `<test-chat>` sessions ([example](https://make.wordpress.org/test/2025/10/07/team-chat-agenda-8-october-2025/)).
-- Run alternating weekly `<test-chat>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759931984959659)) and `<patch-testing-scrub>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759417225194679)) sessions in [#core-test](https://wordpress.slack.com/messages/core-test/). See the [Test Chat Moderator Guide](https://make.wordpress.org/test/handbook/team-reps/test-chat-moderator-guide/) for detailed instructions.
+- Run alternating weekly `<test-chat>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759931984959659)) and `<patch-testing-scrub>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1759417225194679)) sessions in [#core-test](https://wordpress.slack.com/messages/core-test/). See the [Test Chat Moderator Guide](https://make.wordpress.org/test/handbook/team-reps/test-chat-moderator-guide/) and [Patch Testing Scrub Guide](https://make.wordpress.org/test/handbook/team-reps/patch-testing-scrub-guide/) for instructions for each session.
 - Write `<test-chat>` session recaps, and post to [Make WordPress Test](https://make.wordpress.org/test/).
 - Help raise awareness for testing needs, especially for upcoming releases.
 - Raise issues or red flags that other teams should be aware of or discussing.


### PR DESCRIPTION
## Summary
- Link Patch testing scrubbing from the Test Team Handbook page to the published guide.
- Add the Patch Testing Scrub Guide to the Test Team Reps duties section.

## Issue
Fixes #169