### PR TITLE
Include patch version milestones in testing digest

### DIFF
--- a/.github/scripts/weekly-testing-digest.mjs
+++ b/.github/scripts/weekly-testing-digest.mjs
@@ -72,7 +72,7 @@ function buildGitHubURL( type ) {
  * so we use a headless browser that auto-solves it.
  *
  * @returns {Promise<Array<{milestone: string, count: number}>>}
- *          Only versioned milestones (X.X pattern).
+ *          Only versioned milestones (X.X or X.X.X pattern).
  */
 async function fetchTracMilestones() {
 	const browser = await chromium.launch();
@@ -100,14 +100,14 @@ async function fetchTracMilestones() {
 			);
 		}
 
-		// Keep only versioned milestones (e.g. "7.0", "7.1")
+		// Keep only versioned milestones (e.g. "7.0", "7.0.1", "7.1")
 		const versioned = allMilestones.filter( ( m ) =>
-			/^\d+\.\d+$/.test( m.milestone )
+			/^\d+(\.\d+)+$/.test( m.milestone )
 		);
 
 		if ( versioned.length === 0 && allMilestones.length > 0 ) {
 			console.error(
-				`Warning: Found ${ allMilestones.length } milestone(s) but none matched versioned pattern (X.Y).`
+				`Warning: Found ${ allMilestones.length } milestone(s) but none matched versioned pattern (X.Y or X.Y.Z).`
 			);
 		}
 


### PR DESCRIPTION
## Summary
- Update the weekly testing digest milestone filter to include patch version milestones like `7.0.1`.
- Keep two-segment milestones like `7.0` and `7.1` included.
- Update the nearby comments and warning text to match the new behavior.

## Testing
- Ran `node --check .github/scripts/weekly-testing-digest.mjs`.
- Verified the regex includes `7.0`, `7.0.1`, `7.1`, and `6.9.2`.
- Verified it excludes `Future Release`, `Awaiting Review`, `7`, and `7.x`.
- Ran `git diff --check`.

Fixes #170