### PR TITLE
Fix inline code rendering in setup docs

### DIFF
--- a/get-setup-for-testing/database-inspection.md
+++ b/get-setup-for-testing/database-inspection.md
@@ -1,6 +1,6 @@
 # Database Inspection
 
-Some test scenarios require checking or editing database rows directly. If you need a browser-based database tool for a local WordPress development environment, you can add phpMyAdmin to your `wordpress-develop` Docker setup.
+Some test scenarios require checking or editing database rows directly. If you need a browser-based database tool for a local WordPress development environment, you can add phpMyAdmin to the Docker setup for your local [WordPress Develop](https://github.com/WordPress/wordpress-develop) checkout.
 
 ## Using phpMyAdmin
 

--- a/get-setup-for-testing/database-inspection.md
+++ b/get-setup-for-testing/database-inspection.md
@@ -1,6 +1,6 @@
 # Database Inspection
 
-Some test scenarios require checking or editing database rows directly. If you need a browser-based database tool for a local WordPress development environment, you can add phpMyAdmin to the Docker setup for your local [WordPress Develop](https://github.com/WordPress/wordpress-develop) checkout.
+Some test scenarios require checking or editing database rows directly. If you need a browser-based database tool for a local WordPress development environment, you can add phpMyAdmin to your `wordpress-develop` Docker setup.
 
 ## Using phpMyAdmin
 
@@ -29,7 +29,7 @@ Start the service with:
 docker compose up -d phpmyadmin
 ```
 
-Then open `http://localhost:8080` in your browser. This uses the default local database credentials from the WordPress development environment. The default database name is `wordpress_develop`.
+Then open http://localhost:8080 in your browser. This uses the default local database credentials from the WordPress development environment. The default database name is `wordpress_develop`.
 
 When you are finished, stop the service with:
 

--- a/get-setup-for-testing/email-testing.md
+++ b/get-setup-for-testing/email-testing.md
@@ -6,7 +6,7 @@ Email testing is important for WordPress testing because WordPress core relies o
 
 Depending on your testing environment, you can use:
 
-- [Email Logger](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip), a plugin that hooks into the `wp_mail()` function. See the [wp_mail() reference](https://developer.wordpress.org/reference/functions/wp_mail/).
+- [Email Logger](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip) plugin that hooks into the [wp_mail](https://developer.wordpress.org/reference/functions/wp_mail/) function.
 - [Mailpit](https://github.com/axllent/mailpit), a lightweight email testing tool that provides a web interface to view the captured emails.
 
 ### 1. Using Email Logger Plugin
@@ -17,10 +17,10 @@ This method can be used on your local development environment as well as on [Wor
 
 Steps to use:
 
-1. [Download the Email Logger plugin](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip), install it from `Plugins > Add Plugin > Upload Plugin`, and activate it.
+1. [Download](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip) the plugin, install it from `Plugins > Add Plugin > Upload Plugin` and activate it.
 2. Use the `Email Log` menu item to view captured emails.
 
-You can also use this [WordPress Playground instance](https://playground.wordpress.net/?php=8.3&wp=trunk&plugin=https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip), which comes with the Email Logger plugin preinstalled.
+You can also use this [WordPress Playground](https://playground.wordpress.net/?php=8.3&wp=trunk&plugin=https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip) instance that comes with `Email Logger` plugin preinstalled.
 
 ### 2. Using Mailpit
 
@@ -34,7 +34,7 @@ You can browse emails easily through Mailpit's user interface that acts as a mai
 
 Steps to install and use Mailpit:
 
-1. Create `docker-compose.override.yml` with the following code in the root folder of your cloned [WordPress Develop](https://github.com/WordPress/wordpress-develop) repository.
+1. Create `docker-compose.override.yml` with the following code in root folder of your cloned [WordPress Develop](https://github.com/WordPress/wordpress-develop) Repo.
 
 ```yaml
 services:
@@ -56,7 +56,7 @@ services:
 <a href="https://make.wordpress.org/test/files/2026/02/docker-compose-override.png"><img src="https://make.wordpress.org/test/files/2026/02/docker-compose-override.png" alt="Docker Compose Override File" style="max-width: 100%"></a>
 
 2. Run the command `docker compose up -d mail` in your terminal.
-3. Test access to Mailpit at `http://localhost:8025/`.
+3. Test access to Mailpit at http://localhost:8025/.
 4. Add the following snippet to your active theme's `functions.php` or via [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
 
 ```php
@@ -73,7 +73,7 @@ add_filter( 'wp_mail_from', function( $email ) {
 
 ## Other Tools for Mail Testing
 
-- For testing emails with [WordPress Studio](https://developer.wordpress.com/studio/), you can use [WP Mail](https://github.com/jonathanbossenger/wp-mail) by [@jonathanbossenger](https://github.com/jonathanbossenger), a desktop application for logging and viewing emails sent from WordPress Studio local sites.
+- For testing emails with [WordPress Studio](https://developer.wordpress.com/studio/) you can use [WP Mail](https://github.com/jonathanbossenger/wp-mail) by [@jonathanbossenger](https://github.com/jonathanbossenger), a desktop application for logging and viewing emails sent from WordPress Studio local sites.
 
 ## Conclusion
 

--- a/get-setup-for-testing/email-testing.md
+++ b/get-setup-for-testing/email-testing.md
@@ -6,7 +6,7 @@ Email testing is important for WordPress testing because WordPress core relies o
 
 Depending on your testing environment, you can use:
 
-- [Email Logger](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip) plugin that hooks into the [wp_mail](https://developer.wordpress.org/reference/functions/wp_mail/) function.
+- [Email Logger](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip), a plugin that hooks into the `wp_mail()` function. See the [wp_mail() reference](https://developer.wordpress.org/reference/functions/wp_mail/).
 - [Mailpit](https://github.com/axllent/mailpit), a lightweight email testing tool that provides a web interface to view the captured emails.
 
 ### 1. Using Email Logger Plugin
@@ -17,10 +17,10 @@ This method can be used on your local development environment as well as on [Wor
 
 Steps to use:
 
-1. [Download](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip) the plugin, install it from `Plugins > Add Plugin > Upload Plugin` and activate it.
+1. [Download the Email Logger plugin](https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip), install it from `Plugins > Add Plugin > Upload Plugin`, and activate it.
 2. Use the `Email Log` menu item to view captured emails.
 
-You can also use this [WordPress Playground](https://playground.wordpress.net/?php=8.3&wp=trunk&plugin=https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip) instance that comes with `Email Logger` plugin preinstalled.
+You can also use this [WordPress Playground instance](https://playground.wordpress.net/?php=8.3&wp=trunk&plugin=https://make.wordpress.org/test/files/2026/02/wp-email-logger.zip), which comes with the Email Logger plugin preinstalled.
 
 ### 2. Using Mailpit
 
@@ -34,7 +34,7 @@ You can browse emails easily through Mailpit's user interface that acts as a mai
 
 Steps to install and use Mailpit:
 
-1. Create `docker-compose.override.yml` with the following code in root folder of your cloned [WordPress Develop](https://github.com/WordPress/wordpress-develop) Repo.
+1. Create `docker-compose.override.yml` with the following code in the root folder of your cloned [WordPress Develop](https://github.com/WordPress/wordpress-develop) repository.
 
 ```yaml
 services:
@@ -73,7 +73,7 @@ add_filter( 'wp_mail_from', function( $email ) {
 
 ## Other Tools for Mail Testing
 
-- For testing emails with [WordPress Studio](https://developer.wordpress.com/studio/) you can use [WP Mail](https://github.com/jonathanbossenger/wp-mail) by [@jonathanbossenger](https://github.com/jonathanbossenger), a desktop application for logging and viewing emails sent from WordPress Studio local sites.
+- For testing emails with [WordPress Studio](https://developer.wordpress.com/studio/), you can use [WP Mail](https://github.com/jonathanbossenger/wp-mail) by [@jonathanbossenger](https://github.com/jonathanbossenger), a desktop application for logging and viewing emails sent from WordPress Studio local sites.
 
 ## Conclusion
 

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -1,6 +1,6 @@
 # Set Up a Testing Environment
 
-To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. **Patches are created against the `trunk` branch of [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop)**, the development version of WordPress, not the stable release from the [WordPress download page](https://wordpress.org/download/). This guide covers the options available for setting up a testing environment.
+To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. **Patches are created against the [`trunk`](https://github.com/WordPress/wordpress-develop) branch**, the development version of WordPress, not the stable release from wordpress.org/download, so you'll need to work with the development codebase. This guide covers the options available for setting up a testing environment.
 
 ## Choose Your Environment
 
@@ -34,12 +34,10 @@ Before you begin, ensure you have the following installed on your computer:
 
 ### Setup Instructions
 
-**Prefer a video walkthrough?**
-
+**Prefer a video walkthrough?** <br>
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
-1.  **Fork and Clone the Repository**
-
+1.  **Fork and Clone the Repository** <br>
     Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
@@ -48,35 +46,31 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
     Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
-2.  **Install Dependencies**
-
+2.  **Install Dependencies** <br>
     Run the following command to install the necessary JavaScript and PHP tools:
     ```bash
     npm install
     ```
 
-3.  **Build WordPress**
-
+3.  **Build WordPress** <br>
     Compile the source files into a running WordPress instance:
     ```bash
     npm run build:dev
     ```
 
-4.  **Start the Environment**
-
+4.  **Start the Environment** <br>
     Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start
     ```
 
-5.  **Install WordPress**
-
+5.  **Install WordPress** <br>
     Run the installation script to set up the database and site:
     ```bash
     npm run env:install
     ```
 
-Your local WordPress site should now be accessible at `http://localhost:8889`.
+Your local WordPress site should now be accessible at http://localhost:8889.
 
 - **Username:** `admin`
 - **Password:** `password`

--- a/get-setup-for-testing/set-up-a-testing-environment.md
+++ b/get-setup-for-testing/set-up-a-testing-environment.md
@@ -1,6 +1,6 @@
 # Set Up a Testing Environment
 
-To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. **Patches are created against the [`trunk`](https://github.com/WordPress/wordpress-develop) branch**, the development version of WordPress, not the stable release from wordpress.org/download, so you'll need to work with the development codebase. This guide covers the options available for setting up a testing environment.
+To test WordPress core tickets effectively, you need an environment where you can apply patches and run tests. **Patches are created against the `trunk` branch of [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop)**, the development version of WordPress, not the stable release from the [WordPress download page](https://wordpress.org/download/). This guide covers the options available for setting up a testing environment.
 
 ## Choose Your Environment
 
@@ -34,10 +34,12 @@ Before you begin, ensure you have the following installed on your computer:
 
 ### Setup Instructions
 
-**Prefer a video walkthrough?** <br>
+**Prefer a video walkthrough?**
+
 Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?v=LMgn8GjUdNk) as you work through the instructions below.
 
-1.  **Fork and Clone the Repository** <br>
+1.  **Fork and Clone the Repository**
+
     Fork the [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) repository to your GitHub account, then clone it locally:
     ```bash
     git clone https://github.com/YOUR_USERNAME/wordpress-develop.git
@@ -46,25 +48,29 @@ Follow along with this [step-by-step setup guide](https://www.youtube.com/watch?
     ```
     Adding the `upstream` remote allows you to keep your local repository in sync with the latest changes from WordPress core.
 
-2.  **Install Dependencies** <br>
+2.  **Install Dependencies**
+
     Run the following command to install the necessary JavaScript and PHP tools:
     ```bash
     npm install
     ```
 
-3.  **Build WordPress** <br>
+3.  **Build WordPress**
+
     Compile the source files into a running WordPress instance:
     ```bash
     npm run build:dev
     ```
 
-4.  **Start the Environment** <br>
+4.  **Start the Environment**
+
     Ensure Docker Desktop is running, then start the Docker environment:
     ```bash
     npm run env:start
     ```
 
-5.  **Install WordPress** <br>
+5.  **Install WordPress**
+
     Run the installation script to set up the database and site:
     ```bash
     npm run env:install

--- a/get-setup-for-testing/test-core-tickets-with-playground.md
+++ b/get-setup-for-testing/test-core-tickets-with-playground.md
@@ -1,26 +1,26 @@
 # Test Core Tickets with Playground
 
-[WordPress Playground](https://playground.wordpress.net/) is an online platform that lets you experiment and learn about WordPress without affecting your live website. It is a virtual sandbox where you can test features, designs, and settings in a safe and controlled environment. Learn more in the [WordPress Playground documentation](https://wordpress.github.io/wordpress-playground/).
+[WordPress Playground](https://playground.wordpress.net/) is an online platform that lets you experiment and learn about WordPress without affecting your live website. It’s a virtual sandbox where you can test features, designs, and settings in a safe and controlled environment. More about WordPress Playground can be read [here](https://wordpress.github.io/wordpress-playground/). 
 
 ## How to Test Core Tickets with Playground
 
-1. Go to the Trac ticket and check whether it has a GitHub pull request or a patch file. If the ticket has a pull request, you can test it with Playground. If the ticket only has a `.patch` file, this automatic test environment will not work.
+1. Go to the Trac ticket and check that the ticket has a GitHub PR or a patch file. If a ticket has PR, you can test that Trac ticket with Playground. If the Trac ticket has “.patch”. This automatic test environment will not work. 
 
     <a href="https://make.wordpress.org/test/files/2025/10/example-trac-ticket.png"><img src="https://make.wordpress.org/test/files/2025/10/example-trac-ticket.png" alt="Example Trac Ticket" style="max-width: 100%"></a>
 
-2. Click the "View PR" button. It will open the related GitHub pull request as shown in the screenshot below.
+2. Click on the ‘View PR’ button, it will open the respective GitHub PR as shown in the screenshot below.
 
     <a href="https://make.wordpress.org/test/files/2025/10/github-pull-request-example.png"><img src="https://make.wordpress.org/test/files/2025/10/github-pull-request-example.png" alt="GitHub Pull Request Example" style="max-width: 100%"></a>
 
-3. In the pull request comment thread, find the GitHub Actions comment about "Test using WordPress Playground".
+3. On the PR comment thread, it will find the GitHub action default comment about ‘Test using WordPress Playground’ 
 
     <a href="https://make.wordpress.org/test/files/2025/10/github-test-using-playground.png"><img src="https://make.wordpress.org/test/files/2025/10/github-test-using-playground.png" alt="Test using WordPress Playground" style="max-width: 100%"></a>
 
-4. Click the "Test this pull request with WordPress Playground" link. It will create a disposable WordPress website with the changes from the pull request.
+4. You will find a link with the text ‘Test this pull request with WordPress Playground’. Click on this link. It will create a disposable WordPress website with the changes implemented in the PR. 
 
     <a href="https://make.wordpress.org/test/files/2025/10/creating-plaground-site-with-pr.png"><img src="https://make.wordpress.org/test/files/2025/10/creating-plaground-site-with-pr.png" alt="Creating Playground Site with PR" style="max-width: 100%"></a>
 
-5. Click the "Go" button if the page does not redirect automatically to the WordPress site.
+5. Click on the ‘Go’ button if the page doesn’t redirect automatically to the WordPress site. 
 
     <a href="https://make.wordpress.org/test/files/2025/10/playground-site-preparing.png"><img src="https://make.wordpress.org/test/files/2025/10/playground-site-preparing.png" alt="Playground Site Preparing" style="max-width: 100%"></a>
 
@@ -28,12 +28,12 @@
 
     <a href="https://make.wordpress.org/test/files/2025/10/playground-site-with-pr.png"><img src="https://make.wordpress.org/test/files/2025/10/playground-site-with-pr.png" alt="Playground Site with PR" style="max-width: 100%"></a>
 
-There are some limitations to this Playground environment. Learn more in the [Playground limitations documentation](https://wordpress.github.io/wordpress-playground/developers/limitations/).
+There are some limitations to this Playground environment. You can read more [here](https://wordpress.github.io/wordpress-playground/developers/limitations/).
 
 - All changes will be lost when a tab is closed with a Playground instance.
 - All changes will be lost when refreshing the page.
 
-In the WordPress Playground environment, you can test pull requests for feature changes, bug fixes, regression issues, and more.
+In the WordPress Playground environment you can test the PR for the feature changes, bug fixes, regression issues and more.
 
 ## Writing a Test Report
 
@@ -75,7 +75,7 @@ For example, to initiate the Playground with WordPress `trunk` and PHP `8.3` you
 
 ## How to Install and Configure Playground CLI
 
-WordPress Playground CLI can be used as an alternative to the current Docker instance for some WordPress core testing tasks.
+WordPress Playground CLI is a potential replacement for the current Docker instance for testing purposes within the Wordpress Core development scope.
 
 You can refer to this [video guide](https://www.youtube.com/watch?v=-O8oubXyhUg) for a visual walkthrough.
 
@@ -96,8 +96,8 @@ npx @wp-playground/cli@latest server \
 ```
 <img src="https://make.wordpress.org/test/files/2026/04/playground-cli-in-terminal-scaled.webp" alt="Run PlayGround CLI in Terminal" style="max-width: 100%">
 
-Your WordPress instance should now be accessible at `http://localhost:9400`.
-
+Your WordPress instance should now be accessible at: http://localhost:9400
+<br />
 <img src="https://make.wordpress.org/test/files/2026/04/playground-cli-in-browser-scaled.webp" alt="WordPress Playground running locally on port 9400" style="max-width: 100%">
 
 You may also consider creating an alias for this long command in your terminal, so that you don't need to remember and type it every time.
@@ -134,7 +134,6 @@ alias play-start='npx @wp-playground/cli@latest server \
   --site-url=http://localhost:9400 \
   --mount=./src/wp-content/plugins:/wordpress/wp-content/plugins'
 ```
-
 Here, `play-start` is your `alias` that you will be using to run the long npx command. You can choose any name that you can easily remember.
 
 
@@ -152,9 +151,7 @@ To edit it, run `notepad $PROFILE`.
 
 If you don't have an existing `$PROFILE`, you might need to run the following command first to create it:
 
-```powershell
-New-Item -Path $PROFILE -ItemType File -Force
-```
+`New-Item -Path $PROFILE -ItemType File -Force`
 
 The `-Force` flag handles it gracefully. It creates the file (and any missing folders) if it doesn't exist, and does nothing if it already exists.
 
@@ -171,7 +168,7 @@ function play-start {
 }
 ```
 
-Note the backtick character, `` ` ``, instead of `\` for line continuation.
+Note the backtick ` instead of \ for line continuation.
 
 Close your PowerShell and reopen it before calling your alias, which is `play-start` in this example.
 

--- a/get-setup-for-testing/test-core-tickets-with-playground.md
+++ b/get-setup-for-testing/test-core-tickets-with-playground.md
@@ -1,26 +1,26 @@
 # Test Core Tickets with Playground
 
-[WordPress Playground](https://playground.wordpress.net/) is an online platform that lets you experiment and learn about WordPress without affecting your live website. It’s a virtual sandbox where you can test features, designs, and settings in a safe and controlled environment. More about WordPress Playground can be read [here](https://wordpress.github.io/wordpress-playground/). 
+[WordPress Playground](https://playground.wordpress.net/) is an online platform that lets you experiment and learn about WordPress without affecting your live website. It is a virtual sandbox where you can test features, designs, and settings in a safe and controlled environment. Learn more in the [WordPress Playground documentation](https://wordpress.github.io/wordpress-playground/).
 
 ## How to Test Core Tickets with Playground
 
-1. Go to the Trac ticket and check that the ticket has a GitHub PR or a patch file. If a ticket has PR, you can test that Trac ticket with Playground. If the Trac ticket has “.patch”. This automatic test environment will not work. 
+1. Go to the Trac ticket and check whether it has a GitHub pull request or a patch file. If the ticket has a pull request, you can test it with Playground. If the ticket only has a `.patch` file, this automatic test environment will not work.
 
     <a href="https://make.wordpress.org/test/files/2025/10/example-trac-ticket.png"><img src="https://make.wordpress.org/test/files/2025/10/example-trac-ticket.png" alt="Example Trac Ticket" style="max-width: 100%"></a>
 
-2. Click on the ‘View PR’ button, it will open the respective GitHub PR as shown in the screenshot below.
+2. Click the "View PR" button. It will open the related GitHub pull request as shown in the screenshot below.
 
     <a href="https://make.wordpress.org/test/files/2025/10/github-pull-request-example.png"><img src="https://make.wordpress.org/test/files/2025/10/github-pull-request-example.png" alt="GitHub Pull Request Example" style="max-width: 100%"></a>
 
-3. On the PR comment thread, it will find the GitHub action default comment about ‘Test using WordPress Playground’ 
+3. In the pull request comment thread, find the GitHub Actions comment about "Test using WordPress Playground".
 
     <a href="https://make.wordpress.org/test/files/2025/10/github-test-using-playground.png"><img src="https://make.wordpress.org/test/files/2025/10/github-test-using-playground.png" alt="Test using WordPress Playground" style="max-width: 100%"></a>
 
-4. You will find a link with the text ‘Test this pull request with WordPress Playground’. Click on this link. It will create a disposable WordPress website with the changes implemented in the PR. 
+4. Click the "Test this pull request with WordPress Playground" link. It will create a disposable WordPress website with the changes from the pull request.
 
     <a href="https://make.wordpress.org/test/files/2025/10/creating-plaground-site-with-pr.png"><img src="https://make.wordpress.org/test/files/2025/10/creating-plaground-site-with-pr.png" alt="Creating Playground Site with PR" style="max-width: 100%"></a>
 
-5. Click on the ‘Go’ button if the page doesn’t redirect automatically to the WordPress site. 
+5. Click the "Go" button if the page does not redirect automatically to the WordPress site.
 
     <a href="https://make.wordpress.org/test/files/2025/10/playground-site-preparing.png"><img src="https://make.wordpress.org/test/files/2025/10/playground-site-preparing.png" alt="Playground Site Preparing" style="max-width: 100%"></a>
 
@@ -28,12 +28,12 @@
 
     <a href="https://make.wordpress.org/test/files/2025/10/playground-site-with-pr.png"><img src="https://make.wordpress.org/test/files/2025/10/playground-site-with-pr.png" alt="Playground Site with PR" style="max-width: 100%"></a>
 
-There are some limitations to this Playground environment. You can read more [here](https://wordpress.github.io/wordpress-playground/developers/limitations/).
+There are some limitations to this Playground environment. Learn more in the [Playground limitations documentation](https://wordpress.github.io/wordpress-playground/developers/limitations/).
 
 - All changes will be lost when a tab is closed with a Playground instance.
 - All changes will be lost when refreshing the page.
 
-In the WordPress Playground environment you can test the PR for the feature changes, bug fixes, regression issues and more.
+In the WordPress Playground environment, you can test pull requests for feature changes, bug fixes, regression issues, and more.
 
 ## Writing a Test Report
 
@@ -75,7 +75,7 @@ For example, to initiate the Playground with WordPress `trunk` and PHP `8.3` you
 
 ## How to Install and Configure Playground CLI
 
-WordPress Playground CLI is a potential replacement for the current Docker instance for testing purposes within the Wordpress Core development scope.
+WordPress Playground CLI can be used as an alternative to the current Docker instance for some WordPress core testing tasks.
 
 You can refer to this [video guide](https://www.youtube.com/watch?v=-O8oubXyhUg) for a visual walkthrough.
 
@@ -96,8 +96,8 @@ npx @wp-playground/cli@latest server \
 ```
 <img src="https://make.wordpress.org/test/files/2026/04/playground-cli-in-terminal-scaled.webp" alt="Run PlayGround CLI in Terminal" style="max-width: 100%">
 
-Your WordPress instance should now be accessible at: `http://localhost:9400`
-<br />
+Your WordPress instance should now be accessible at `http://localhost:9400`.
+
 <img src="https://make.wordpress.org/test/files/2026/04/playground-cli-in-browser-scaled.webp" alt="WordPress Playground running locally on port 9400" style="max-width: 100%">
 
 You may also consider creating an alias for this long command in your terminal, so that you don't need to remember and type it every time.
@@ -134,6 +134,7 @@ alias play-start='npx @wp-playground/cli@latest server \
   --site-url=http://localhost:9400 \
   --mount=./src/wp-content/plugins:/wordpress/wp-content/plugins'
 ```
+
 Here, `play-start` is your `alias` that you will be using to run the long npx command. You can choose any name that you can easily remember.
 
 
@@ -151,7 +152,9 @@ To edit it, run `notepad $PROFILE`.
 
 If you don't have an existing `$PROFILE`, you might need to run the following command first to create it:
 
-`New-Item -Path $PROFILE -ItemType File -Force`
+```powershell
+New-Item -Path $PROFILE -ItemType File -Force
+```
 
 The `-Force` flag handles it gracefully. It creates the file (and any missing folders) if it doesn't exist, and does nothing if it already exists.
 
@@ -168,7 +171,7 @@ function play-start {
 }
 ```
 
-Note the backtick ` instead of \ for line continuation.
+Note the backtick character, `` ` ``, instead of `\` for line continuation.
 
 Close your PowerShell and reopen it before calling your alias, which is `play-start` in this example.
 


### PR DESCRIPTION
## Summary
- Fixes Markdown patterns that caused inline code and links to render awkwardly on setup pages.
- Replaces fragile inline HTML spacing with normal Markdown spacing.
- Cleans related wording on the affected setup, email testing, database inspection, and Playground pages.

Fixes WordPress/test-handbook#175

## Testing
- Ran `git diff --check`.
- Checked for nested inline-code links.
- Checked for unbalanced code fences.
- Checked that no em dashes, smart quotes, CRLF characters, or `<br>` tags remain in the affected files.