### PR TITLE
Update TestFlow plugin links

### DIFF
--- a/team-reps/patch-testing-scrub-guide.md
+++ b/team-reps/patch-testing-scrub-guide.md
@@ -118,7 +118,7 @@ TestFlow turns the script and tips above into an interactive session screen: a r
 
 ### Where to get it
 
-Try it instantly via [WordPress Playground](https://playground.wordpress.net/?plugin=https%3A%2F%2Fgithub.com%2Fozgursar%2Ftestflow%2Farchive%2Frefs%2Ftags%2Fv0.5.2.zip&url=/wp-admin/admin.php?page=testflow) — no installation required. You can also download it from [GitHub](https://github.com/ozgursar/testflow) and install it as a regular plugin. See the [proposal and discussion](https://github.com/WordPress/test-handbook/issues/165) for background and status.
+Try it instantly via [WordPress Playground](https://playground.wordpress.net/?plugin=testflow&url=/wp-admin/admin.php?page=testflow) — no installation required. You can also download it from [WordPress Plugin Directory](https://wordpress.org/plugins/testflow/) and install it as a regular plugin. See the [proposal and discussion](https://github.com/WordPress/test-handbook/issues/165) for background and status.
 
 ### Screenshot
 

--- a/team-reps/test-chat-moderator-guide.md
+++ b/team-reps/test-chat-moderator-guide.md
@@ -280,7 +280,7 @@ After the meeting:
 
 ## Automating This Guide with a Session Plugin
 
-Currently, running a Test Chat means manually copying and pasting each message from this page into Slack. Before you do that, you can use the [TestFlow](https://github.com/ozgursar/testflow) plugin to conduct the whole session instead: it keeps the script, session variables, and timer in one screen and copies each message to your clipboard for you.
+Currently, running a Test Chat means manually copying and pasting each message from this page into Slack. Before you do that, you can use the [TestFlow](https://wordpress.org/plugins/testflow/) plugin to conduct the whole session instead: it keeps the script, session variables, and timer in one screen and copies each message to your clipboard for you.
 
 ### What it does
 


### PR DESCRIPTION
TestFlow plugin has been added to WordPress.org plugin directory.
This PR updates the plugin links from my personal GitHub account to [WordPress plugin directory](https://wordpress.org/plugins/testflow/).